### PR TITLE
Support substitution tokens

### DIFF
--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -49,7 +49,7 @@ export default class Assessment extends Component {
 
       return (
         <View
-          key={item.ident}
+          key={index}
           as="li"
           padding="small none"
           background="default"

--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -12,11 +12,12 @@ import Pill from "@instructure/ui-elements/lib/components/Pill";
 export default class Assessment extends Component {
   render() {
     const doc = this.props.doc;
-
     const assessmentNode = doc.querySelector("assessment");
-
+    if (assessmentNode == null) {
+      // Not yet loaded
+      return null;
+    }
     const title = assessmentNode.getAttribute("title");
-
     const metadata = getMetadataFields(
       assessmentNode.parentNode.querySelector("assessment > qtimetadata")
     );

--- a/src/AssessmentList.js
+++ b/src/AssessmentList.js
@@ -1,0 +1,47 @@
+import React, { Component } from "react";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
+import AssessmentListItem from "./AssessmentListItem";
+import { getResourceHref } from "./utils";
+
+export default class AssessmentList extends Component {
+  render() {
+    const resources = this.props.resources
+      .filter(node => node.querySelector("file"))
+      .map(node => ({
+        identifier: node.getAttribute("identifier"),
+        href: node.querySelector("file").getAttribute("href"),
+        dependencyHrefs: Array.from(node.querySelectorAll("dependency")).map(
+          node => {
+            const identifier = node.getAttribute("identifierref");
+            const resource = this.props.resourceMap.get(identifier);
+            return getResourceHref(resource);
+          }
+        )
+      }));
+
+    const listItems =
+      this.props.entryMap.size &&
+      resources.map(({ href, identifier, dependencyHrefs }, index) => {
+        return (
+          <AssessmentListItem
+            dependencyHrefs={dependencyHrefs}
+            entryMap={this.props.entryMap}
+            href={`/${href}`}
+            identifier={identifier}
+            key={index}
+            src={this.props.src}
+          />
+        );
+      });
+
+    return (
+      <div className="Cartridge-content-inner">
+        <Heading level="h1">
+          <ScreenReaderContent>Assessments</ScreenReaderContent>
+        </Heading>
+        <ul className="Assessments ExpandCollapseList">{listItems}</ul>
+      </div>
+    );
+  }
+}

--- a/src/AssessmentListItem.js
+++ b/src/AssessmentListItem.js
@@ -19,39 +19,25 @@ export default class AssessmentListItem extends Component {
 
   async componentDidMount() {
     const parser = new DOMParser();
-
     const path = this.props.href.substr(1);
-
     const entry = this.props.entryMap.get(path);
-
     const xml = await getTextFromEntry(entry);
-
     const doc = parser.parseFromString(xml, "text/xml");
-
     const depPath = this.props.dependencyHrefs[0];
-
     const depEntry = this.props.entryMap.get(depPath);
-
     const depXml = await getTextFromEntry(depEntry);
-
     const depDoc = parser.parseFromString(depXml, "text/xml");
-
     const title =
       doc.querySelector("assessment") &&
       doc.querySelector("assessment").getAttribute("title");
-
     const pointsPossibleNode =
       depDoc && depDoc.querySelector("quiz > assignment > points_possible");
-
     const points =
       pointsPossibleNode && parseFloat(pointsPossibleNode.textContent);
-
     const questionCount = doc.querySelectorAll("assessment > section > item")
       .length;
-
     const workflowStateNode =
       depDoc && depDoc.querySelector("quiz > assignment > workflow_state");
-
     const workflowState = workflowStateNode && workflowStateNode.textContent;
 
     this.setState({
@@ -80,7 +66,7 @@ export default class AssessmentListItem extends Component {
           </span>
           <div style={{ flex: 1 }}>
             <div>
-              <Link as={RouterLink} to={`${this.props.href}`}>
+              <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
                 {this.state.title}
               </Link>
             </div>

--- a/src/Assignment.js
+++ b/src/Assignment.js
@@ -6,26 +6,23 @@ import Icon from "@instructure/ui-icons/lib/Line/IconAssignment";
 export default class Assignment extends Component {
   render() {
     const doc = this.props.doc;
-
     const assignmentNode = doc.querySelector("assignment");
-
+    if (assignmentNode == null) {
+      // Not yet loaded
+      return null;
+    }
     const title = assignmentNode.querySelector("title").textContent;
-
     const descriptionHtml = assignmentNode.querySelector("text").textContent;
-
     const submissionFormats = Array.from(
       assignmentNode.querySelectorAll("submission_formats > format")
     ).map(node => node.getAttribute("type"));
-
     const gradableNode = assignmentNode.querySelector("gradable");
-
     const points =
       gradableNode &&
       gradableNode.textContent === "true" &&
       gradableNode.getAttribute("points_possible")
         ? parseFloat(gradableNode.getAttribute("points_possible"))
         : 0;
-
     const labelColor = "#AD4AA0";
 
     return (

--- a/src/Assignment.js
+++ b/src/Assignment.js
@@ -49,7 +49,7 @@ export default class Assignment extends Component {
               <div style={{ marginTop: "12px", marginBottom: "12px" }}>
                 <span style={{ fontWeight: "bold" }}>Submission formats</span>:{" "}
                 {submissionFormats.map(format => (
-                  <span>{format}</span>
+                  <span key={format}>{format}</span>
                 ))}
               </div>
             </React.Fragment>

--- a/src/AssignmentList.js
+++ b/src/AssignmentList.js
@@ -1,0 +1,47 @@
+import React, { Component } from "react";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
+import AssignmentListItem from "./AssignmentListItem";
+import { getResourceHref } from "./utils";
+
+export default class AssignmentList extends Component {
+  render() {
+    const resources = this.props.resources
+      .filter(node => node.querySelector("file"))
+      .map(node => ({
+        identifier: node.getAttribute("identifier"),
+        href: node.querySelector("file").getAttribute("href"),
+        dependencyHrefs: Array.from(node.querySelectorAll("dependency")).map(
+          node => {
+            const identifier = node.getAttribute("identifierref");
+            const resource = this.props.resourceMap.get(identifier);
+            return getResourceHref(resource);
+          }
+        )
+      }));
+
+    const listItems =
+      this.props.entryMap.size &&
+      resources.map(({ href, dependencyHrefs, identifier }, index) => {
+        return (
+          <AssignmentListItem
+            key={index}
+            src={this.props.src}
+            href={`/${href}`}
+            identifier={identifier}
+            dependencyHrefs={dependencyHrefs}
+            entryMap={this.props.entryMap}
+          />
+        );
+      });
+
+    return (
+      <div className="Cartridge-content-inner">
+        <Heading level="h1">
+          <ScreenReaderContent>Assignments</ScreenReaderContent>
+        </Heading>
+        <ul className="Assignments ExpandCollapseList">{listItems}</ul>
+      </div>
+    );
+  }
+}

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -19,33 +19,23 @@ export default class AssignmentListItem extends Component {
 
   async componentDidMount() {
     const parser = new DOMParser();
-
     const path = this.props.href.substr(1);
-
     const entry = this.props.entryMap.get(path);
-
     const xml = await getTextFromEntry(entry);
-
     const doc = parser.parseFromString(xml, "text/xml");
-
     const title =
       doc.querySelector("title") && doc.querySelector("title").textContent;
-
     const description = doc.querySelector("text").textContent;
-
     const gradableNode = doc.querySelector("gradable");
-
     const points =
       gradableNode &&
       gradableNode.textContent === "true" &&
       gradableNode.getAttribute("points_possible")
         ? parseFloat(gradableNode.getAttribute("points_possible"))
         : 0;
-
     const workflowStateNode = doc.querySelector(
       "extensions > assignment > workflow_state"
     );
-
     const workflowState = workflowStateNode && workflowStateNode.textContent;
 
     this.setState({
@@ -73,7 +63,7 @@ export default class AssignmentListItem extends Component {
             <IconAssignment color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`${this.props.href}`}>
+            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
               {this.state.title}
             </Link>
           </div>

--- a/src/Discussion.js
+++ b/src/Discussion.js
@@ -6,13 +6,9 @@ import RichContent from "./RichContent";
 export default class Discussion extends Component {
   render() {
     const doc = this.props.doc;
-
-    const assignmentNode = doc.querySelector("topic");
-
-    const title = assignmentNode.querySelector("title").textContent;
-
-    const descriptionHtml = assignmentNode.querySelector("text").textContent;
-
+    const topicNode = doc.querySelector("topic");
+    const title = topicNode.querySelector("title").textContent;
+    const descriptionHtml = topicNode.querySelector("text").textContent;
     const labelColor = "#6f2562";
 
     return (

--- a/src/Discussion.js
+++ b/src/Discussion.js
@@ -7,6 +7,10 @@ export default class Discussion extends Component {
   render() {
     const doc = this.props.doc;
     const topicNode = doc.querySelector("topic");
+    if (topicNode == null) {
+      // Not yet loaded
+      return null;
+    }
     const title = topicNode.querySelector("title").textContent;
     const descriptionHtml = topicNode.querySelector("text").textContent;
     const labelColor = "#6f2562";

--- a/src/DiscussionList.js
+++ b/src/DiscussionList.js
@@ -1,0 +1,45 @@
+import React, { Component } from "react";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
+import { getResourceHref } from "./utils";
+import DiscussionListItem from "./DiscussionListItem";
+
+export default class DiscussionList extends Component {
+  render() {
+    const resources = this.props.resources.map(node => ({
+      dependencyHrefs: Array.from(node.querySelectorAll("dependency")).map(
+        node => {
+          const identifier = node.getAttribute("identifierref");
+          const resource = this.props.resourceMap.get(identifier);
+          return getResourceHref(resource);
+        }
+      ),
+      href: node.querySelector("file").getAttribute("href"),
+      identifier: node.getAttribute("identifier")
+    }));
+
+    const listItems =
+      this.props.entryMap.size &&
+      resources.map(({ dependencyHrefs, href, identifier }, index) => {
+        return (
+          <DiscussionListItem
+            key={index}
+            src={this.props.src}
+            href={`/${href}`}
+            identifier={identifier}
+            dependencyHrefs={dependencyHrefs}
+            entryMap={this.props.entryMap}
+          />
+        );
+      });
+
+    return (
+      <div className="Cartridge-content-inner">
+        <Heading level="h1">
+          <ScreenReaderContent>Discussions</ScreenReaderContent>
+        </Heading>
+        <ul className="Discussions ExpandCollapseList">{listItems}</ul>
+      </div>
+    );
+  }
+}

--- a/src/DiscussionListItem.js
+++ b/src/DiscussionListItem.js
@@ -19,35 +19,22 @@ export default class DiscussionListItem extends Component {
 
   async componentDidMount() {
     const parser = new DOMParser();
-
     const path = this.props.href.substr(1);
-
     const entry = this.props.entryMap.get(path);
-
     const xml = await getTextFromEntry(entry);
-
     const doc = parser.parseFromString(xml, "text/xml");
-
     const title = doc.querySelector("title").textContent;
-
     const depPath = this.props.dependencyHrefs[0];
-
     const depEntry = this.props.entryMap.get(depPath);
-
     const depXml = await getTextFromEntry(depEntry);
-
     const depDoc = parser.parseFromString(depXml, "text/xml");
-
     const workflowStateNode = depDoc.querySelector(
       "topicMeta > workflow_state"
     );
-
     const workflowState = workflowStateNode && workflowStateNode.textContent;
-
     const pointsPossibleNode =
       depDoc &&
       depDoc.querySelector("topicMeta > assignment > points_possible");
-
     const points =
       pointsPossibleNode && parseFloat(pointsPossibleNode.textContent);
 
@@ -76,7 +63,7 @@ export default class DiscussionListItem extends Component {
           </span>
 
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`${this.props.href}`}>
+            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
               {this.state.title}
             </Link>
           </div>

--- a/src/EntryDocument.js
+++ b/src/EntryDocument.js
@@ -28,7 +28,7 @@ export default class EntryDocument extends Component {
 
   async update() {
     const src = this.props.src;
-    const path = this.props.href.substr(1);
+    const path = this.props.href;
     const id = `${src}/${path}`;
 
     if (documents.has(id)) {

--- a/src/EntryDocument.js
+++ b/src/EntryDocument.js
@@ -45,7 +45,7 @@ export default class EntryDocument extends Component {
   }
 
   render() {
-    if (this.state.isLoading) {
+    if (this.state.isLoading || this.state.doc == null) {
       return <span />;
     }
 

--- a/src/FileList.js
+++ b/src/FileList.js
@@ -1,0 +1,43 @@
+import React, { Component } from "react";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
+import FileListItem from "./FileListItem";
+
+export default class FileList extends Component {
+  render() {
+    const fileResources = this.props.resources
+      .filter(node => node.querySelector("file"))
+      .map(node => ({
+        href: node.querySelector("file").getAttribute("href"),
+        identifier: node.getAttribute("identifier"),
+        metadata: node.querySelector("metadata")
+      }))
+      .filter(({ href }) => {
+        return href.startsWith("wiki_content/") === false;
+      });
+
+    const listItems =
+      this.props.entryMap.size &&
+      fileResources.map(({ dependencyHrefs, href, identifier }, index) => {
+        return (
+          <FileListItem
+            dependencyHrefs={dependencyHrefs}
+            entryMap={this.props.entryMap}
+            href={`/${href}`}
+            identifier={identifier}
+            key={index}
+            src={this.props.src}
+          />
+        );
+      });
+
+    return (
+      <div className="Cartridge-content-inner">
+        <Heading level="h1">
+          <ScreenReaderContent>Files</ScreenReaderContent>
+        </Heading>
+        <ul className="Files ExpandCollapseList">{listItems}</ul>
+      </div>
+    );
+  }
+}

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -56,7 +56,7 @@ export default class FileListItem extends Component {
             <IconPaperclip color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`${this.props.href}`}>
+            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
               {this.state.title.replace(/^(web_resources\/)/, "")}
             </Link>
           </div>

--- a/src/Image.js
+++ b/src/Image.js
@@ -17,14 +17,10 @@ export default class Image extends Component {
   }
 
   async componentDidMount() {
-    const entryKey = this.props.href.substr(1);
-
+    const entryKey = this.props.href;
     const entry = this.props.entryMap.get(entryKey);
-
     const filename = basename(entry.filename);
-
     const blob = await getBlobFromEntry(entry);
-
     const dataUrl = await blobToDataUrl(blob);
 
     this.setState({

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -1,0 +1,148 @@
+import React, { Component } from "react";
+import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import Link from "@instructure/ui-elements/lib/components/Link";
+
+import { getExtension } from "./utils.js";
+import { resourceTypes } from "./constants";
+import NavLink from "./NavLink";
+import AssignmentListItem from "./AssignmentListItem";
+import AssessmentListItem from "./AssessmentListItem";
+import DiscussionListItem from "./DiscussionListItem";
+import WikiContentListItem from "./WikiContentListItem";
+import FileListItem from "./FileListItem";
+import WebLinkListItem from "./WebLinkListItem";
+
+export default class ModulesList extends Component {
+  render() {
+    const moduleComponents = this.props.modules.map(
+      ({ title, ref, items, identifier }, index) => {
+        const itemComponents = items.map((item, index) => {
+          const isSubheading = item.href == null;
+
+          if (isSubheading) {
+            return (
+              <li key={index} className="ExpandCollapseList-item">
+                <div className="ExpandCollapseList-item-inner">
+                  <h3>{item.title}</h3>
+                </div>
+              </li>
+            );
+          }
+
+          const extension = getExtension(item.href);
+
+          const isWikiContent =
+            item.type === resourceTypes.WEB_CONTENT &&
+            ["html", "htm"].includes(extension);
+
+          if (isWikiContent) {
+            return (
+              <WikiContentListItem
+                dependencyHrefs={item.dependencyHrefs}
+                entryMap={this.props.entryMap}
+                key={index}
+                href={`/${item.href}`}
+                identifier={item.identifierref}
+                item={item}
+                src={this.props.src}
+              />
+            );
+          }
+
+          if (item.type === resourceTypes.ASSIGNMENT) {
+            return (
+              <AssignmentListItem
+                dependencyHrefs={item.dependencyHrefs}
+                entryMap={this.props.entryMap}
+                href={`/${item.href}`}
+                identifier={item.identifierref}
+                item={item}
+                key={index}
+                src={this.props.src}
+              />
+            );
+          }
+
+          if (item.type === resourceTypes.ASSESSMENT_CONTENT) {
+            return (
+              <AssessmentListItem
+                dependencyHrefs={item.dependencyHrefs}
+                entryMap={this.props.entryMap}
+                href={`/${item.href}`}
+                identifier={item.identifierref}
+                item={item}
+                key={index}
+                src={this.props.src}
+              />
+            );
+          }
+
+          if (item.type === resourceTypes.DISCUSSION_TOPIC) {
+            return (
+              <DiscussionListItem
+                dependencyHrefs={item.dependencyHrefs}
+                entryMap={this.props.entryMap}
+                href={`/${item.href}`}
+                identifier={item.identifierref}
+                item={item}
+                key={index}
+                src={this.props.src}
+              />
+            );
+          }
+
+          if (item.type === resourceTypes.WEB_CONTENT) {
+            return (
+              <FileListItem
+                entryMap={this.props.entryMap}
+                href={`/${item.href}`}
+                key={index}
+                metadata={item.metadata}
+                src={this.props.src}
+              />
+            );
+          }
+
+          if (item.type === resourceTypes.WEB_LINK) {
+            return <WebLinkListItem key={index} item={item} />;
+          }
+
+          return (
+            <li key={index} className="ExpandCollapseList-item">
+              <div className="ExpandCollapseList-item-inner">
+                <div>
+                  {item.type === resourceTypes.WEB_LINK && (
+                    <span className="resource-icon">
+                      <IconExternalLink />
+                    </span>
+                  )}
+                </div>
+
+                <div style={{ flex: 1 }}>
+                  {item.href && (
+                    <Link as={NavLink} to={`resources/${item.identifier}`}>
+                      <span>{item.title || "Untitled"} (unidentified)</span>
+                    </Link>
+                  )}
+                </div>
+              </div>
+            </li>
+          );
+        });
+
+        return (
+          <li className="Module" key={index}>
+            <Heading level="h3" id={`modules/${identifier}`}>
+              <div style={{ padding: "12px 0 6px 0" }}>{title}</div>
+            </Heading>
+
+            <ul className="ModuleItems ExpandCollapseList">{itemComponents}</ul>
+          </li>
+        );
+      }
+    );
+
+    return moduleComponents;
+  }
+}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -105,7 +105,13 @@ export default class ModulesList extends Component {
           }
 
           if (item.type === resourceTypes.WEB_LINK) {
-            return <WebLinkListItem key={index} item={item} />;
+            return (
+              <WebLinkListItem
+                key={index}
+                identifier={item.identifierref}
+                item={item}
+              />
+            );
           }
 
           return (

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -14,6 +14,7 @@ import Assignment from "./Assignment";
 import Discussion from "./Discussion";
 import Assessment from "./Assessment";
 import WikiContent from "./WikiContent";
+import WebLink from "./WebLink";
 import { getBlobFromEntry } from "./utils";
 import { getExtension, getResourceHref } from "./utils";
 
@@ -92,7 +93,19 @@ export default class Resource extends Component {
     }
 
     let resourceComponent;
-    if (resource.getAttribute("type") === resourceTypes.ASSESSMENT_CONTENT) {
+    if (resource.getAttribute("type") === resourceTypes.WEB_LINK) {
+      resourceComponent = (
+        <EntryDocument
+          entryMap={this.props.entryMap}
+          href={href}
+          render={doc => <WebLink doc={doc} />}
+          src={this.props.src}
+          type="text/xml"
+        />
+      );
+    } else if (
+      resource.getAttribute("type") === resourceTypes.ASSESSMENT_CONTENT
+    ) {
       resourceComponent = (
         <EntryDocument
           entryMap={this.props.entryMap}
@@ -162,8 +175,6 @@ export default class Resource extends Component {
         );
       }
     }
-
-    // console.debug(resource.getAttribute("type"));
 
     const currentIndex = this.props.moduleItems.findIndex(
       item => `${item.href}` === href

--- a/src/RichContent.js
+++ b/src/RichContent.js
@@ -4,6 +4,7 @@ import createDOMPurify from "dompurify";
 import {
   CC_FILE_PREFIX,
   WIKI_REFERENCE,
+  CANVAS_COURSE_REFERENCE,
   CANVAS_OBJECT_REFERENCE
 } from "./constants";
 import Text from "@instructure/ui-elements/lib/components/Text";
@@ -52,7 +53,7 @@ export default class RichContent extends Component {
 
     {
       const links = Array.from(fragment.querySelectorAll("a[href]"));
-      const moduleExp = RegExp(`${CANVAS_OBJECT_REFERENCE}/(modules)/(.*)`);
+      const moduleExp = RegExp(`${CANVAS_OBJECT_REFERENCE}/(.*)/(.*)`);
       await Promise.all(
         links
           .filter(link => moduleExp.test(link.getAttribute("href")))
@@ -60,7 +61,22 @@ export default class RichContent extends Component {
             const resourceId = (link.getAttribute("href") || "").match(
               moduleExp
             )[2];
-            link.setAttribute("href", `#/modules/${resourceId}`);
+            link.setAttribute("href", `#/resources/${resourceId}`);
+          })
+      );
+    }
+
+    {
+      const links = Array.from(fragment.querySelectorAll("a[href]"));
+      const moduleExp = RegExp(`${CANVAS_COURSE_REFERENCE}/(.*)/(.*)`);
+      await Promise.all(
+        links
+          .filter(link => moduleExp.test(link.getAttribute("href")))
+          .map(async link => {
+            const resourceId = (link.getAttribute("href") || "").match(
+              moduleExp
+            )[2];
+            link.setAttribute("href", `#/resources/${resourceId}`);
           })
       );
     }

--- a/src/RichContent.js
+++ b/src/RichContent.js
@@ -3,6 +3,7 @@ import { getBlobFromEntry, blobToDataUrl } from "./utils";
 import createDOMPurify from "dompurify";
 import {
   CC_FILE_PREFIX,
+  CC_FILE_PREFIX_OLD,
   WIKI_REFERENCE,
   CANVAS_COURSE_REFERENCE,
   CANVAS_OBJECT_REFERENCE
@@ -87,11 +88,14 @@ export default class RichContent extends Component {
         .filter(
           img =>
             img.getAttribute("src") &&
-            img.getAttribute("src").indexOf(CC_FILE_PREFIX) > -1
+            (img.getAttribute("src").indexOf(CC_FILE_PREFIX_OLD) > -1 ||
+              img.getAttribute("src").indexOf(CC_FILE_PREFIX) > -1)
         )
         .map(async img => {
           const src = img.getAttribute("src").split("?")[0];
-          const entryKey = src.replace(CC_FILE_PREFIX, "web_resources");
+          const entryKey = src
+            .replace(CC_FILE_PREFIX_OLD, "web_resources")
+            .replace(CC_FILE_PREFIX, "web_resources");
           const entry = this.props.entryMap.get(decodeURIComponent(entryKey));
 
           if (entry) {

--- a/src/RichContent.js
+++ b/src/RichContent.js
@@ -41,7 +41,9 @@ export default class RichContent extends Component {
         links
           .filter(link => wikiExp.test(link.getAttribute("href")))
           .map(async link => {
-            const slug = (link.getAttribute("href") || "").match(wikiExp)[2];
+            const slug = (link.getAttribute("href") || "")
+              .split("?")[0]
+              .match(wikiExp)[2];
             const href = `wiki_content/${slug}.html`;
             const entry = this.props.entryMap.get(href);
             if (entry && this.props.resourceIdsByHrefMap.has(href)) {
@@ -59,9 +61,9 @@ export default class RichContent extends Component {
         links
           .filter(link => moduleExp.test(link.getAttribute("href")))
           .map(async link => {
-            const resourceId = (link.getAttribute("href") || "").match(
-              moduleExp
-            )[2];
+            const resourceId = (link.getAttribute("href") || "")
+              .split("?")[0]
+              .match(moduleExp)[2];
             link.setAttribute("href", `#/resources/${resourceId}`);
           })
       );
@@ -74,9 +76,9 @@ export default class RichContent extends Component {
         links
           .filter(link => moduleExp.test(link.getAttribute("href")))
           .map(async link => {
-            const resourceId = (link.getAttribute("href") || "").match(
-              moduleExp
-            )[2];
+            const resourceId = (link.getAttribute("href") || "")
+              .split("?")[0]
+              .match(moduleExp)[2];
             link.setAttribute("href", `#/resources/${resourceId}`);
           })
       );

--- a/src/WebLink.js
+++ b/src/WebLink.js
@@ -5,13 +5,14 @@ import Icon from "@instructure/ui-icons/lib/Line/IconExternalLink";
 export default class WebLink extends Component {
   render() {
     const doc = this.props.doc;
-
+    if (doc.querySelector("url") == null) {
+      // Not yet loaded
+      return null;
+    }
+    const href = doc.querySelector("url").getAttribute("href");
     const title = doc.querySelector("title")
       ? doc.querySelector("title").textContent
       : "Untitled";
-
-    const href = doc.querySelector("url").getAttribute("href");
-
     const labelColor = "#AD4AA0";
 
     return (

--- a/src/WebLinkListItem.js
+++ b/src/WebLinkListItem.js
@@ -19,7 +19,7 @@ export default class WebLinkListItem extends Component {
 
           <div style={{ flex: 1 }}>
             {this.props.item.href && (
-              <Link as={NavLink} to={`${this.props.item.href}`}>
+              <Link as={NavLink} to={`resources/${this.props.identifier}`}>
                 <span>{this.props.item.title || "Untitled"}</span>
               </Link>
             )}

--- a/src/WebLinkListItem.js
+++ b/src/WebLinkListItem.js
@@ -1,0 +1,31 @@
+import React, { Component } from "react";
+import Link from "@instructure/ui-elements/lib/components/Link";
+import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
+import NavLink from "./NavLink";
+import { resourceTypes } from "./constants";
+
+export default class WebLinkListItem extends Component {
+  render() {
+    return (
+      <li className="ExpandCollapseList-item">
+        <div className="ExpandCollapseList-item-inner">
+          <div>
+            {this.props.item.type === resourceTypes.WEB_LINK && (
+              <span className="resource-icon">
+                <IconExternalLink />
+              </span>
+            )}
+          </div>
+
+          <div style={{ flex: 1 }}>
+            {this.props.item.href && (
+              <Link as={NavLink} to={`${this.props.item.href}`}>
+                <span>{this.props.item.title || "Untitled"}</span>
+              </Link>
+            )}
+          </div>
+        </div>
+      </li>
+    );
+  }
+}

--- a/src/WikiContent.js
+++ b/src/WikiContent.js
@@ -9,9 +9,7 @@ export default class WikiContent extends Component {
     const title = doc.querySelector("title")
       ? doc.querySelector("title").textContent
       : "Untitled";
-
     const html = doc.body ? doc.body.innerHTML : ""; // doc.body.innerHTML;
-
     const labelColor = "#8A6240";
 
     return (
@@ -30,7 +28,11 @@ export default class WikiContent extends Component {
           {title}
         </Heading>
 
-        <RichContent html={html} entryMap={this.props.entryMap} />
+        <RichContent
+          entryMap={this.props.entryMap}
+          html={html}
+          resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
+        />
       </React.Fragment>
     );
   }

--- a/src/WikiContent.js
+++ b/src/WikiContent.js
@@ -6,9 +6,8 @@ import RichContent from "./RichContent";
 export default class WikiContent extends Component {
   render() {
     const doc = this.props.doc;
-    const title = doc.querySelector("title")
-      ? doc.querySelector("title").textContent
-      : "Untitled";
+    const title =
+      doc.querySelector("title") && doc.querySelector("title").textContent;
     const html = doc.body ? doc.body.innerHTML : ""; // doc.body.innerHTML;
     const labelColor = "#8A6240";
 
@@ -24,9 +23,11 @@ export default class WikiContent extends Component {
           <span>Page</span>
         </div>
 
-        <Heading level="h1" margin="0 0 small">
-          {title}
-        </Heading>
+        {title != null && (
+          <Heading level="h1" margin="0 0 small">
+            {title}
+          </Heading>
+        )}
 
         <RichContent
           entryMap={this.props.entryMap}

--- a/src/WikiContentList.js
+++ b/src/WikiContentList.js
@@ -1,0 +1,65 @@
+import React, { Component } from "react";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
+import { getExtension } from "./utils"; // getResourceHref
+import WikiContentListItem from "./WikiContentListItem";
+
+export default class WikiContentList extends Component {
+  render() {
+    const resources = this.props.resources
+      .filter(node => {
+        const isFallback = node
+          .getAttribute("identifier")
+          .endsWith("_fallback");
+
+        if (isFallback) {
+          const identifier = node
+            .getAttribute("identifier")
+            .split("_fallback")[0];
+
+          const resource = this.props.resourceMap.get(identifier);
+
+          if (resource != null) {
+            return false;
+          }
+        }
+
+        return true;
+      })
+      .filter(node => node.querySelector("file"))
+      .map(node => ({
+        identifier: node.getAttribute("identifier"),
+        href: node.querySelector("file").getAttribute("href")
+      }))
+      // needs filter to filter out dependencies
+      .filter(({ href }) => {
+        const extension = getExtension(href);
+
+        return ["html", "htm"].includes(extension);
+      });
+
+    const listItems =
+      this.props.entryMap.size &&
+      resources.map(({ dependencyHrefs, href, identifier }, index) => {
+        return (
+          <WikiContentListItem
+            entryMap={this.props.entryMap}
+            key={href}
+            dependencyHrefs={dependencyHrefs}
+            href={`/${href}`}
+            identifier={identifier}
+            src={this.props.src}
+          />
+        );
+      });
+
+    return (
+      <div className="Cartridge-content-inner">
+        <Heading level="h1">
+          <ScreenReaderContent>Wiki content</ScreenReaderContent>
+        </Heading>
+        <ul className="Discussions ExpandCollapseList">{listItems}</ul>
+      </div>
+    );
+  }
+}

--- a/src/WikiContentListItem.js
+++ b/src/WikiContentListItem.js
@@ -20,23 +20,15 @@ export default class WikiContentListItem extends Component {
 
   async componentDidMount() {
     const parser = new DOMParser();
-
     const path = this.props.href.substr(1);
-
     const entry = this.props.entryMap.get(path);
-
     const xml = await getTextFromEntry(entry);
-
     const doc = parser.parseFromString(xml, "text/html");
-
     const itemTitle = this.props.item != null && this.props.item.title;
-
     const title = itemTitle
       ? itemTitle
       : doc.querySelector("title") && doc.querySelector("title").textContent;
-
     const workflowStateNode = doc.querySelector('meta[name="workflow_state"]');
-
     const workflowState =
       workflowStateNode && workflowStateNode.getAttribute("content");
 
@@ -63,7 +55,7 @@ export default class WikiContentListItem extends Component {
             <IconDocument color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`${this.props.href}`}>
+            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
               {this.state.title || basename(this.props.href)}
             </Link>
           </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,25 +1,26 @@
 export const CC_FILE_PREFIX = "%24IMS-CC-FILEBASE%24";
 export const WIKI_REFERENCE = "%24WIKI_REFERENCE%24";
+export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 
 export const resourceTypes = {
-  WEB_CONTENT: "webcontent",
+  ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",
+  ASSIGNMENT: "assignment_xmlv1p0",
   ASSOCIATED_CONTENT:
     "associatedcontent/imscc_xmlv1p1/learning-application-resource",
+  BLTI: "imsbasiclti_xmlv1p0",
   DISCUSSION_TOPIC: "imsdt_xmlv1p1",
-  ASSIGNMENT: "assignment_xmlv1p0",
-  WEB_LINK: "imswl_xmlv1p1",
-  ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",
   QUESTION_BANK: "imsqti_xmlv1p2/imscc_xmlv1p1/question-bank",
-  BLTI: "imsbasiclti_xmlv1p0"
+  WEB_CONTENT: "webcontent",
+  WEB_LINK: "imswl_xmlv1p1"
 };
 
 export const questionTypes = {
+  ESSAY: "cc.essay.v0p1",
+  FILL_IN_THE_BLANK: "cc.fib.v0p1",
   MULTIPLE_CHOICE: "cc.multiple_choice.v0p1",
   MULTIPLE_RESPONSE: "cc.multiple_response.v0p1",
-  TRUEFALSE: "cc.true_false.v0p1",
-  FILL_IN_THE_BLANK: "cc.fib.v0p1",
   PATTERN_MATCH: "cc.pattern_match.v0p1",
-  ESSAY: "cc.essay.v0p1"
+  TRUEFALSE: "cc.true_false.v0p1"
 };
 
 export const questionTypeLabels = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 export const CC_FILE_PREFIX = "%24IMS-CC-FILEBASE%24";
 export const WIKI_REFERENCE = "%24WIKI_REFERENCE%24";
 export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
+export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";
 
 export const resourceTypes = {
   ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,5 @@
 export const CC_FILE_PREFIX = "%24IMS-CC-FILEBASE%24";
+export const CC_FILE_PREFIX_OLD = "%24IMS_CC_FILEBASE%24"; // mistaken, replaced, but supported: https://github.com/instructure/canvas-lms/commit/d1b508676bf2713cdb09bed7145899728b102ac7
 export const WIKI_REFERENCE = "%24WIKI_REFERENCE%24";
 export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";

--- a/src/utils.js
+++ b/src/utils.js
@@ -90,3 +90,7 @@ export function getResourceHref(resource) {
 
   return null;
 }
+
+export function getExtension(uri) {
+  return uri.split(".").pop();
+}

--- a/tests/test.accessibility-workshop.js
+++ b/tests/test.accessibility-workshop.js
@@ -33,18 +33,63 @@ test("Basic elements exist", async t => {
 
 test("Next and previous links", async t => {
   await t.click(Selector("a").withText("Ally: Accessibility Workshop"));
-  await t.click(Selector("a").withText("Accessibility FAQ"));
-  await t.expect(Selector("h1").withText(`Accessibility FAQ`).exists).ok();
-  await t.click(Selector("a").withText("Next"));
-  await t.expect(Selector("h1").withText(`What is ALLY?`).exists).ok();
-  await t.click(Selector("a").withText("Next"));
+
   await t
+    .click(Selector("a").withText("Accessibility FAQ"))
+    .expect(Selector("h1").withText(`Accessibility FAQ`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`What is ALLY?`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
     .expect(
       Selector("h1").withText(`Alt Text: Writing Alternative Text`).exists
     )
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`Caption Hub`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`Accessibility in your life`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`Share your "Before" Courses`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`Your courses, Accessible`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`Call it out to your Students`).exists)
+    .ok()
+    .click(Selector("a").withText("Next"))
+    .expect(Selector("h1").withText(`Accessibility Resources`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`Call it out to your Students`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`Your courses, Accessible`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`Share your "Before" Courses`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`Accessibility in your life`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`Caption Hub`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(
+      Selector("h1").withText(`Alt Text: Writing Alternative Text`).exists
+    )
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`What is ALLY?`).exists)
+    .ok()
+    .click(Selector("a").withText("Previous"))
+    .expect(Selector("h1").withText(`Accessibility FAQ`).exists)
     .ok();
-  await t.click(Selector("a").withText("Previous"));
-  await t.expect(Selector("h1").withText(`What is ALLY?`).exists).ok();
 });
 
 test("Pages", async t => {

--- a/tests/test.accessibility-workshop.js
+++ b/tests/test.accessibility-workshop.js
@@ -1,6 +1,20 @@
 import { Selector } from "testcafe";
 
-fixture`Dashboard`.page`http://localhost:5000/`;
+fixture`Accessibility Workshop cartridge`.page`http://localhost:5000/`;
+
+test("Resource not found", async t => {
+  await t
+    .click(Selector("a").withText("Ally: Accessibility Workshop"))
+    .expect(
+      Selector("h3").withText("Part 1: Overview: Accessibility and ALLY").exists
+    )
+    .ok("Header shows", { timeout: 20000 });
+
+  await t
+    .navigateTo("#/resources/notfound")
+    .expect(Selector("span").withText("Not found").exists)
+    .ok();
+});
 
 test("Basic elements exist", async t => {
   await t
@@ -104,5 +118,9 @@ test("Files", async t => {
     .expect(Selector("a").withText("files_page_falconer.png").exists)
     .ok()
     .expect(Selector("a").withText("Ally - Student Documentation.docx").exists)
-    .ok();
+    .ok()
+    .expect(Selector("a").withText("wiki_content").exists)
+    .notOk()
+    .expect(Selector("a").withText("the-time-is-now").exists)
+    .notOk();
 });

--- a/tests/test.canvas-levels-of-learning.js
+++ b/tests/test.canvas-levels-of-learning.js
@@ -1,0 +1,25 @@
+import { Selector } from "testcafe";
+
+fixture`Canvas Levels of Learning XP`.page`http://localhost:5000/`;
+
+test("Substition token (CANVAS_COURSE_REFERENCE)", async t => {
+  await t
+    .click(Selector("a").withText("Canvas Levels of Learning XP"))
+    .expect(Selector("h3").withText("Getting Started").exists)
+    .ok("Header shows", { timeout: 35000 })
+    .click(Selector("a").withText("Pages Study Material - Videos"))
+    .click(Selector("a").withText("Skip"))
+    .expect(Selector("h1").withText(`Pages Quiz`).exists)
+    .ok();
+});
+
+test("Substition token (CANVAS_OBJECT_REFERENCE)", async t => {
+  await t
+    .click(Selector("a").withText("Canvas Levels of Learning XP"))
+    .expect(Selector("h3").withText("Getting Started").exists)
+    .ok("Header shows", { timeout: 35000 })
+    .click(Selector("a").withText("Arc Study Material - Guides"))
+    .click(Selector("a").withText("Skip"))
+    .expect(Selector("h1").withText(`Arc`).exists)
+    .ok();
+});

--- a/tests/test.us-history-since-1877.js
+++ b/tests/test.us-history-since-1877.js
@@ -1,14 +1,12 @@
 import { Selector } from "testcafe";
 
-fixture`Dashboard`.page`http://localhost:5000/`;
+fixture`US History Since 1877`.page`http://localhost:5000/`;
 
 test("Organization item titles show for pages", async t => {
   await t
     .click(Selector("a").withText("US History Since 1877"))
-    .expect(Selector("h3").withText("Main Repository").exists, "foo", {
-      timeout: 5000
-    })
-    .ok()
+    .expect(Selector("h3").withText("Main Repository").exists)
+    .ok("Header shows", { timeout: 20000 })
     .expect(Selector("a").withText(`The First Measured Century`).exists, "bar")
     .ok()
     .expect(

--- a/tests/test.us-history-since-1877.js
+++ b/tests/test.us-history-since-1877.js
@@ -16,3 +16,32 @@ test("Organization item titles show for pages", async t => {
     )
     .ok();
 });
+
+test("Web link", async t => {
+  await t
+    .click(Selector("a").withText("US History Since 1877"))
+    .click(Selector("a").withText("Gumbo"))
+    .expect(Selector("span").withText("EXTERNAL LINK").exists)
+    .ok()
+    .expect(Selector("h1").withText("Gumbo").exists)
+    .ok()
+    .expect(
+      Selector("a").withText("Click here to open link in new window").exists
+    )
+    .ok();
+});
+
+test("Web link", async t => {
+  await t
+    .click(Selector("a").withText("US History Since 1877"))
+    .expect(Selector("h3").withText("Main Repository").exists)
+    .ok("Header shows", { timeout: 20000 })
+    .expect(Selector("a").withText(`The First Measured Century`).exists, "bar")
+    .ok()
+    .expect(
+      Selector("a").withText(
+        `The Women of Hull House: Harnessing Statistics for Progressive Reform`
+      ).exists
+    )
+    .ok();
+});


### PR DESCRIPTION
Doing this led me to use `/resources/:resource_id` for routes.

Fixes #2