### PR TITLE
Ensure htm/html file uploads show up as files, not wiki pages

### DIFF
--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -57,7 +57,8 @@ export default class FileListItem extends Component {
           </span>
           <div style={{ flex: 1 }}>
             <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
-              {this.state.title.replace(/^(web_resources\/)/, "")}
+              {this.props.title ||
+                this.state.title.replace(/^(web_resources\/)/, "")}
             </Link>
           </div>
 

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -3,8 +3,7 @@ import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import Link from "@instructure/ui-elements/lib/components/Link";
 
-import { getExtension } from "./utils.js";
-import { resourceTypes } from "./constants";
+import { resourceTypes, WIKI_CONTENT_HREF_PREFIX } from "./constants";
 import NavLink from "./NavLink";
 import AssignmentListItem from "./AssignmentListItem";
 import AssessmentListItem from "./AssessmentListItem";
@@ -30,11 +29,10 @@ export default class ModulesList extends Component {
             );
           }
 
-          const extension = getExtension(item.href);
-
           const isWikiContent =
             item.type === resourceTypes.WEB_CONTENT &&
-            ["html", "htm"].includes(extension);
+            typeof item.href === "string" &&
+            item.href.includes(WIKI_CONTENT_HREF_PREFIX);
 
           if (isWikiContent) {
             return (
@@ -101,6 +99,7 @@ export default class ModulesList extends Component {
                 key={index}
                 metadata={item.metadata}
                 src={this.props.src}
+                title={item.title}
               />
             );
           }

--- a/src/WikiContentList.js
+++ b/src/WikiContentList.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
-import { getExtension } from "./utils"; // getResourceHref
+import { WIKI_CONTENT_HREF_PREFIX } from "./constants";
 import WikiContentListItem from "./WikiContentListItem";
 
 export default class WikiContentList extends Component {
@@ -32,11 +32,10 @@ export default class WikiContentList extends Component {
         href: node.querySelector("file").getAttribute("href")
       }))
       // needs filter to filter out dependencies
-      .filter(({ href }) => {
-        const extension = getExtension(href);
-
-        return ["html", "htm"].includes(extension);
-      });
+      .filter(
+        ({ href }) =>
+          typeof href === "string" && href.includes(WIKI_CONTENT_HREF_PREFIX)
+      );
 
     const listItems =
       this.props.entryMap.size &&

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,8 @@ export const WIKI_REFERENCE = "%24WIKI_REFERENCE%24";
 export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";
 
+export const WIKI_CONTENT_HREF_PREFIX = "wiki_content";
+
 export const resourceTypes = {
   ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",
   ASSIGNMENT: "assignment_xmlv1p0",


### PR DESCRIPTION
Fixes CM-554

Test Plan:
 - Load up a cartridge that contains an html file upload (the ticket has a great example)
 - Ensure that the item shows up as a file upload on the module list page (not a wiki page).
 - Ensure that the item does not show up on the wiki content list page.
 - Ensure that the item shows up on the file list page.

