### PR TITLE
Fix: Make regular assignments viewable

### DIFF
--- a/src/Assignment.js
+++ b/src/Assignment.js
@@ -1,9 +1,7 @@
 import React, { Component } from "react";
-import Heading from "@instructure/ui-elements/lib/components/Heading";
-import RichContent from "./RichContent";
-import Icon from "@instructure/ui-icons/lib/Line/IconAssignment";
-import { basename } from "path";
 import { CC_FILE_PREFIX, CC_FILE_PREFIX_OLD } from "./constants";
+import { generateFriendlyStringFromSubmissionFormats } from "./utils";
+import AssignmentBody from "./AssignmentBody";
 
 export default class Assignment extends Component {
   render() {
@@ -24,9 +22,9 @@ export default class Assignment extends Component {
           .replace(CC_FILE_PREFIX, "web_resources")
       )
     );
-    const submissionFormats = Array.from(
-      assignmentNode.querySelectorAll("submission_formats > format")
-    ).map(node => node.getAttribute("type"));
+    const submissionFormats = assignmentNode.querySelector("submission_types")
+      .textContent;
+
     const gradableNode = assignmentNode.querySelector("gradable");
     const points =
       gradableNode &&
@@ -37,73 +35,18 @@ export default class Assignment extends Component {
     const labelColor = "#AD4AA0";
 
     return (
-      <React.Fragment>
-        <div className="resource-label" style={{ color: labelColor }}>
-          <div
-            className="resource-label-icon"
-            style={{ backgroundColor: labelColor }}
-          >
-            <Icon color="primary-inverse" />
-          </div>
-          <span>Assignment</span>
-        </div>
-
-        <Heading level="h1" margin="0 0 small">
-          {title}
-        </Heading>
-        {submissionFormats.length > 0 && (
-          <React.Fragment>
-            <div style={{ marginTop: "12px", marginBottom: "12px" }}>
-              <span style={{ fontWeight: "bold" }}>Submission formats</span>:{" "}
-              {submissionFormats.map(format => (
-                <span className="submission-format" key={format}>
-                  {format}
-                </span>
-              ))}
-            </div>
-          </React.Fragment>
+      <AssignmentBody
+        title={title}
+        descriptionHtml={descriptionHtml}
+        labelColor={labelColor}
+        pointsPossible={points}
+        submissionFormats={generateFriendlyStringFromSubmissionFormats(
+          submissionFormats
         )}
-
-        {gradableNode != null && (
-          <div>
-            <span style={{ fontWeight: "bold" }}>Points</span>: {points}
-          </div>
-        )}
-
-        {descriptionHtml &&
-          descriptionHtml.length > 0 && (
-            <RichContent
-              html={descriptionHtml}
-              getUrlForPath={this.props.getUrlForPath}
-              resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
-            />
-          )}
-
-        {attachments.length > 0 && (
-          <React.Fragment>
-            <Heading level="h2">Attachments</Heading>
-            <ul>
-              {attachments.map(attachment => {
-                return (
-                  <li key={attachment}>
-                    {this.props.resourceIdsByHrefMap.has(attachment) ? (
-                      <a
-                        href={`#/resources/${this.props.resourceIdsByHrefMap.get(
-                          attachment
-                        )}`}
-                      >
-                        {basename(attachment)}
-                      </a>
-                    ) : (
-                      basename(attachment)
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </React.Fragment>
-        )}
-      </React.Fragment>
+        getUrlForPath={this.props.getUrlForPath}
+        resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
+        attachments={attachments}
+      />
     );
   }
 }

--- a/src/AssignmentBody.js
+++ b/src/AssignmentBody.js
@@ -1,0 +1,83 @@
+import React, { PureComponent } from "react";
+import { basename } from "path";
+import Heading from "@instructure/ui-elements/lib/components/Heading";
+import Icon from "@instructure/ui-icons/lib/Line/IconAssignment";
+import RichContent from "./RichContent";
+
+export default class AssignmentBody extends PureComponent {
+  render() {
+    return (
+      <React.Fragment>
+        <div
+          className="resource-label"
+          style={{ color: this.props.labelColor }}
+        >
+          <div
+            className="resource-label-icon"
+            style={{ backgroundColor: this.props.labelColor }}
+          >
+            <Icon color="primary-inverse" />
+          </div>
+          <span>Assignment</span>
+        </div>
+
+        <Heading level="h1" margin="0 0 small">
+          {this.props.title}
+        </Heading>
+        {this.props.submissionFormats &&
+          this.props.submissionFormats.length > 0 && (
+            <React.Fragment>
+              <div style={{ marginTop: "12px", marginBottom: "12px" }}>
+                <span style={{ fontWeight: "bold" }}>Submitting</span>:{" "}
+                <span className="submission-format">
+                  {this.props.submissionFormats}
+                </span>
+              </div>
+            </React.Fragment>
+          )}
+
+        {this.props.pointsPossible != null && (
+          <div>
+            <span style={{ fontWeight: "bold" }}>Points</span>:{" "}
+            {this.props.pointsPossible}
+          </div>
+        )}
+
+        {this.props.descriptionHtml &&
+          this.props.descriptionHtml.length > 0 && (
+            <RichContent
+              html={this.props.descriptionHtml}
+              getUrlForPath={this.props.getUrlForPath}
+              resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
+            />
+          )}
+
+        {this.props.attachments &&
+          this.props.attachments.length > 0 && (
+            <React.Fragment>
+              <Heading level="h2">Attachments</Heading>
+              <ul>
+                {this.props.attachments.map(attachment => {
+                  return (
+                    <li key={attachment}>
+                      {this.props.resourceIdsByHrefMap.has(attachment) ? (
+                        <a
+                          href={`#/resources/${this.props.resourceIdsByHrefMap.get(
+                            attachment
+                          )}`}
+                        >
+                          {basename(attachment)}
+                        </a>
+                      ) : (
+                        basename(attachment)
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </React.Fragment>
+          )}
+      </React.Fragment>
+    );
+  }
+}

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -1,9 +1,5 @@
 import React, { Component } from "react";
-import { Link as RouterLink } from "react-router-dom";
-import IconAssignment from "@instructure/ui-icons/lib/Line/IconAssignment";
-import IconUnpublished from "@instructure/ui-icons/lib/Line/IconUnpublished";
-import IconPublish from "@instructure/ui-icons/lib/Solid/IconPublish";
-import Link from "@instructure/ui-elements/lib/components/Link";
+import AssignmentListItemBody from "./AssignmentListItemBody";
 
 export default class AssignmentListItem extends Component {
   constructor(props) {
@@ -55,35 +51,14 @@ export default class AssignmentListItem extends Component {
       : "secondary";
 
     return (
-      <li className="ExpandCollapseList-item">
-        <div className="ExpandCollapseList-item-inner">
-          <span className="resource-icon">
-            <IconAssignment color={iconColor} />
-          </span>
-          <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
-              {this.state.title}
-            </Link>
-          </div>
-
-          {this.state.points != null && (
-            <div className="ExpandCollapseList-item-pts">
-              {this.state.points} points
-            </div>
-          )}
-
-          {this.state.workflowState != null && (
-            <div className="ExpandCollapseList-item-workflow-state">
-              {this.state.workflowState === "unpublished" && (
-                <IconUnpublished color={iconColor} />
-              )}
-              {["published", "active"].includes(this.state.workflowState) && (
-                <IconPublish color={iconColor} />
-              )}
-            </div>
-          )}
-        </div>
-      </li>
+      <AssignmentListItemBody
+        iconColor={iconColor}
+        identifier={this.props.identifier}
+        title={this.state.title}
+        description={this.state.workflowState}
+        points={this.state.points}
+        workflowState={this.state.workflowState}
+      />
     );
   }
 }

--- a/src/AssignmentListItemBody.js
+++ b/src/AssignmentListItemBody.js
@@ -1,0 +1,42 @@
+import React, { PureComponent } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import IconAssignment from "@instructure/ui-icons/lib/Line/IconAssignment";
+import IconUnpublished from "@instructure/ui-icons/lib/Line/IconUnpublished";
+import IconPublish from "@instructure/ui-icons/lib/Solid/IconPublish";
+import Link from "@instructure/ui-elements/lib/components/Link";
+
+export default class AssignmentListItemBody extends PureComponent {
+  render() {
+    return (
+      <li className="ExpandCollapseList-item">
+        <div className="ExpandCollapseList-item-inner">
+          <span className="resource-icon">
+            <IconAssignment color={this.props.iconColor} />
+          </span>
+          <div style={{ flex: 1 }}>
+            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+              {this.props.title}
+            </Link>
+          </div>
+
+          {this.props.points != null && (
+            <div className="ExpandCollapseList-item-pts">
+              {this.props.points} points
+            </div>
+          )}
+
+          {this.props.workflowState != null && (
+            <div className="ExpandCollapseList-item-workflow-state">
+              {this.props.workflowState === "unpublished" && (
+                <IconUnpublished color={this.props.iconColor} />
+              )}
+              {["published", "active"].includes(this.props.workflowState) && (
+                <IconPublish color={this.props.iconColor} />
+              )}
+            </div>
+          )}
+        </div>
+      </li>
+    );
+  }
+}

--- a/src/AssociatedContentAssignment.js
+++ b/src/AssociatedContentAssignment.js
@@ -1,0 +1,59 @@
+import React, { Component } from "react";
+import AssignmentBody from "./AssignmentBody";
+import { ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX } from "./constants";
+import {
+  generateFriendlyStringFromSubmissionFormats,
+  getAssignmentSettingsHref
+} from "./utils";
+
+export default class AssociatedContentAssignment extends Component {
+  async componentDidMount() {
+    const parser = new DOMParser();
+    const settingsXml = await this.props.getTextByPath(
+      getAssignmentSettingsHref(this.props.identifier)
+    );
+    const settings = parser.parseFromString(settingsXml, "text/xml");
+    const pointsPossibleNode = settings.querySelector("points_possible");
+    const pointsPossible =
+      pointsPossibleNode && parseFloat(pointsPossibleNode.textContent);
+
+    const submissionNode = settings.querySelector("submission_types");
+    const submissionFormats = submissionNode && submissionNode.textContent;
+
+    this.setState({
+      pointsPossible,
+      submissionFormats: generateFriendlyStringFromSubmissionFormats(
+        submissionFormats
+      )
+    });
+  }
+
+  render() {
+    const doc = this.props.doc;
+    if (this.state == null || doc.querySelector("body") == null) {
+      // Not yet loaded
+      return null;
+    }
+    const title = doc
+      .querySelector("title")
+      .textContent.replace(
+        ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX,
+        ""
+      );
+    const descriptionHtml = doc.querySelector("body").innerHTML;
+
+    const labelColor = "#AD4AA0";
+
+    return (
+      <AssignmentBody
+        title={title}
+        descriptionHtml={descriptionHtml}
+        labelColor={labelColor}
+        pointsPossible={this.state.pointsPossible}
+        submissionFormats={this.state.submissionFormats}
+        getTextByPath={this.props.getTextByPath}
+        getUrlForPath={this.props.getUrlForPath}
+      />
+    );
+  }
+}

--- a/src/AssociatedContentAssignmentList.js
+++ b/src/AssociatedContentAssignmentList.js
@@ -1,11 +1,10 @@
 import React, { Component } from "react";
-import { Trans } from "@lingui/macro";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import ScreenReaderContent from "@instructure/ui-a11y/lib/components/ScreenReaderContent";
-import AssignmentListItem from "./AssignmentListItem";
+import AssociatedContentAssignmentListItem from "./AssociatedContentAssignmentListItem";
 import { getAssignmentListResources } from "./utils";
 
-export default class AssignmentList extends Component {
+export default class AssociatedContentAssignmentList extends Component {
   render() {
     if (this.props.resources.length === 0) {
       return null;
@@ -15,7 +14,7 @@ export default class AssignmentList extends Component {
     const listItems = resources.map(
       ({ href, dependencyHrefs, identifier }, index) => {
         return (
-          <AssignmentListItem
+          <AssociatedContentAssignmentListItem
             dependencyHrefs={dependencyHrefs}
             getTextByPath={this.props.getTextByPath}
             href={`/${href}`}
@@ -30,9 +29,7 @@ export default class AssignmentList extends Component {
     return (
       <div className="Cartridge-content-inner">
         <Heading level="h1">
-          <ScreenReaderContent>
-            <Trans>Assignments</Trans>
-          </ScreenReaderContent>
+          <ScreenReaderContent>Assignments</ScreenReaderContent>
         </Heading>
         <ul className="Assignments ExpandCollapseList">{listItems}</ul>
       </div>

--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -1,0 +1,69 @@
+import React, { Component } from "react";
+import { getAssignmentSettingsHref } from "./utils.js";
+import { ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX } from "./constants";
+import AssignmentListItemBody from "./AssignmentListItemBody";
+
+export default class AssociatedContentAssignmentListItem extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isLoading: true,
+      title: null,
+      workflowState: null
+    };
+  }
+
+  async componentDidMount() {
+    const parser = new DOMParser();
+    const path = this.props.href.substr(1);
+    const assignmentXml = await this.props.getTextByPath(path);
+    const doc = parser.parseFromString(assignmentXml, "text/xml");
+    const title =
+      doc.querySelector("title") &&
+      doc
+        .querySelector("title")
+        .textContent.replace(
+          ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX,
+          ""
+        );
+
+    const settingsXml = this.props.getTextByPath(
+      getAssignmentSettingsHref(this.props.identifier)
+    );
+    const settings = parser.parseFromString(settingsXml, "text/xml");
+    const pointsPossibleNode = settings.querySelector("points_possible");
+    const pointsPossible =
+      pointsPossibleNode && parseFloat(pointsPossibleNode.textContent);
+    const workflowStateNode = settings.querySelector("workflow_state");
+    const workflowState = workflowStateNode && workflowStateNode.textContent;
+
+    this.setState({
+      isLoading: false,
+      title,
+      pointsPossible,
+      workflowState
+    });
+  }
+
+  render() {
+    if (this.state.isLoading) {
+      return null;
+    }
+
+    const iconColor = ["published", "active"].includes(this.state.workflowState)
+      ? "success"
+      : "secondary";
+
+    return (
+      <AssignmentListItemBody
+        iconColor={iconColor}
+        identifier={this.props.identifier}
+        title={this.state.title}
+        description={this.state.workflowState}
+        points={this.state.pointsPossible}
+        workflowState={this.state.workflowState}
+      />
+    );
+  }
+}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -12,6 +12,9 @@ import WikiContentListItem from "./WikiContentListItem";
 import FileListItem from "./FileListItem";
 import WebLinkListItem from "./WebLinkListItem";
 
+import { getAssignmentSettingsHref } from "./utils.js";
+import AssociatedContentAssignmentListItem from "./AssociatedContentAssignmentListItem";
+
 export default class ModulesList extends Component {
   render() {
     const moduleComponents = this.props.modules.map(
@@ -60,6 +63,25 @@ export default class ModulesList extends Component {
                 src={this.props.src}
               />
             );
+          }
+
+          if (item.type === resourceTypes.ASSOCIATED_CONTENT) {
+            const associatedContentAssignmentSettings = this.props.isValidPath(
+              getAssignmentSettingsHref(item.identifierref)
+            );
+            if (associatedContentAssignmentSettings) {
+              return (
+                <AssociatedContentAssignmentListItem
+                  dependencyHrefs={item.dependencyHrefs}
+                  getTextByPath={this.props.getTextByPath}
+                  href={`/${item.href}`}
+                  identifier={item.identifierref}
+                  item={item}
+                  key={index}
+                  src={this.props.src}
+                />
+              );
+            }
           }
 
           if (item.type === resourceTypes.ASSESSMENT_CONTENT) {

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -12,6 +12,7 @@ import Flex, { FlexItem } from "@instructure/ui-layout/lib/components/Flex";
 import EntryDocument from "./EntryDocument";
 import Image from "./Image";
 import Assignment from "./Assignment";
+import AssociatedContentAssignment from "./AssociatedContentAssignment";
 import Discussion from "./Discussion";
 import Assessment from "./Assessment";
 import WikiContent from "./WikiContent";
@@ -185,6 +186,22 @@ export default class Resource extends Component {
               getTextByPath={this.props.getTextByPath}
               getUrlForPath={this.props.getUrlForPath}
               doc={doc}
+            />
+          )}
+          src={this.props.src}
+          type="text/xml"
+        />
+      ),
+      [resourceTypes.ASSOCIATED_CONTENT]: (
+        <EntryDocument
+          getTextByPath={this.props.getTextByPath}
+          href={href}
+          render={doc => (
+            <AssociatedContentAssignment
+              getTextByPath={this.props.getTextByPath}
+              getUrlForPath={this.props.getUrlForPath}
+              doc={doc}
+              identifier={this.props.identifier}
             />
           )}
           src={this.props.src}

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,8 +3,9 @@ export const CC_FILE_PREFIX_OLD = "%24IMS_CC_FILEBASE%24"; // mistaken, replaced
 export const WIKI_REFERENCE = "%24WIKI_REFERENCE%24";
 export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";
-
 export const WIKI_CONTENT_HREF_PREFIX = "wiki_content";
+export const SUBMISSION_TYPE_JOIN_STRING = ", or ";
+export const ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX = /(^Assignment: )/;
 
 export const resourceTypes = {
   ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",
@@ -34,4 +35,22 @@ export const questionTypeLabels = {
   [questionTypes.FILL_IN_THE_BLANK]: "Fill in the blank",
   [questionTypes.PATTERN_MATCH]: "Pattern match",
   [questionTypes.ESSAY]: "Essay"
+};
+
+export const submissionTypes = {
+  ONLINE_UPLOAD: "online_upload",
+  ONLINE_TEXT_ENTRY: "online_text_entry",
+  ONLINE_URL: "online_url",
+  MEDIA_RECORDING: "media_recording",
+  ON_PAPER: "on_paper",
+  NONE: "none"
+};
+
+export const submissionTypeLabels = {
+  [submissionTypes.ONLINE_UPLOAD]: "a file upload",
+  [submissionTypes.ONLINE_TEXT_ENTRY]: "a text entry box",
+  [submissionTypes.ONLINE_URL]: "a website url",
+  [submissionTypes.MEDIA_RECORDING]: "a media recording",
+  [submissionTypes.ON_PAPER]: "on paper",
+  [submissionTypes.NONE]: "Nothing"
 };


### PR DESCRIPTION
Note:
 - This problem is a result of a bug where assignments are exported
   as associated content if the course is exported through Canvas.
   Assignments are correctly exported as assignments if the course imscc
   is downloaded through Commons. A ticket will be filed notifying Canvas
   of this problem.

Test Plan:
 - Export a course with assignments through Canvas.
 - The assignments do not show up as unidentified.
 - Clicking on an assignment shows its information.
 - The assignments list contains all of the course assignments.

fixes CM-549