### PR TITLE
Implements flag to hide quizzes responses

### DIFF
--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -70,6 +70,7 @@ export default class Assessment extends Component {
     });
 
     const labelColor = "#A1403E";
+    const showQuestions = !window.location.href.includes('hide-responses')
 
     return (
       <React.Fragment>
@@ -102,11 +103,15 @@ export default class Assessment extends Component {
           )}
         </FormFieldGroup>
 
-        <Heading level="h2" margin="medium 0 small">
-          Questions
-        </Heading>
+        {showQuestions && (
+          <div>
+            <Heading level="h2" margin="medium 0 small">
+              Questions
+            </Heading>
 
-        <ul className="assessment-questions">{questionComponents}</ul>
+            <ul className="assessment-questions">{questionComponents}</ul>
+          </div>
+        )}
       </React.Fragment>
     );
   }

--- a/tests/test.assesstments.js
+++ b/tests/test.assesstments.js
@@ -1,0 +1,17 @@
+import { Selector } from "testcafe"
+import { __await } from "tslib"
+
+fixture`Assesstments`
+
+test("when hide-responses flag is set in the url, quizzes responses are hidden", async t => {
+  const assesstmentQuestions = Selector(".assessment-questions")
+
+  await t.navigateTo(
+    "http://localhost:5000/?src=https%3A//s3.amazonaws.com/public-imscc/292b3b44b9b34309b7c6e1f92019007f.imscc%23/resources/ie2b10297e865025977a509593d42a326%3F"
+  )
+  await t.expect(assesstmentQuestions.exists)
+  await t.navigateTo(
+    "http://localhost:5000/?src=https%3A//s3.amazonaws.com/public-imscc/292b3b44b9b34309b7c6e1f92019007f.imscc%23/resources/ie2b10297e865025977a509593d42a326%3Fhide-responses"
+  )
+  await t.expect(assesstmentQuestions.exists).notOk()
+})


### PR DESCRIPTION
When `hide-responses` is present in the URL, the quizzes questions part is hidden. This is a 2 part work (commons work will be added to the new ui).