### PR TITLE
Display content can't be previewed when resource is a webContent with a external tool

### DIFF
--- a/src/Assignment.js
+++ b/src/Assignment.js
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import { CC_FILE_PREFIX, CC_FILE_PREFIX_OLD } from "./constants";
 import { generateFriendlyStringFromSubmissionFormats } from "./utils";
 import AssignmentBody from "./AssignmentBody";
+import PreviewUnavailable from "./PreviewUnavailable";
 
 export default class Assignment extends Component {
   render() {
@@ -24,7 +25,9 @@ export default class Assignment extends Component {
     );
     const submissionFormats = assignmentNode.querySelector("submission_types")
       .textContent;
-
+    const externalToolNode = doc.querySelector(
+      "external_tool_external_identifier"
+    );
     const gradableNode = assignmentNode.querySelector("gradable");
     const points =
       gradableNode &&
@@ -34,7 +37,9 @@ export default class Assignment extends Component {
         : 0;
     const labelColor = "#AD4AA0";
 
-    return (
+    return !!externalToolNode ? (
+      PreviewUnavailable()
+    ) : (
       <AssignmentBody
         title={title}
         descriptionHtml={descriptionHtml}

--- a/tests/test.associated-content-assignment.js
+++ b/tests/test.associated-content-assignment.js
@@ -172,3 +172,28 @@ test("Displays 'Preview not available' for external tool content", async t => {
     )
     .ok();
 });
+
+fixture`Web content with a external tool`
+  .page`http://localhost:5000/?src=https://s3.amazonaws.com/public-imscc/COURSE+WITH+A+GOOGLE+DRIVE+LTI+CLOUD+ASSIGNMENT+AND+A+QUIZZES2+ASSIGNMENT.zip#/`;
+
+test("Displays 'Preview not available' when web content is an external tool", async t => {
+  const assignmentsNav = Selector("a").withText("Assignments (2)");
+  await t
+    .expect(Selector("header").exists)
+    .ok()
+    .click(assignmentsNav);
+
+  const externalGoogleDriveLTI = Selector("a").withText(
+    "Google Drive LTI Assignment"
+  );
+  await t
+    .expect(externalGoogleDriveLTI.exists)
+    .ok()
+    .click(externalGoogleDriveLTI);
+
+  await t
+    .expect(
+      Selector("span").withText("External Tool Content Can't be Previewed")
+    )
+    .ok();
+});


### PR DESCRIPTION
Display content can't be previewed when resource is a webContent with a external tool