### PR TITLE
Fix: make external tool links show up correctly

### DIFF
--- a/src/ExternalToolListItem.js
+++ b/src/ExternalToolListItem.js
@@ -1,0 +1,27 @@
+import React, { Component } from "react";
+import Link from "@instructure/ui-elements/lib/components/Link";
+import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
+import NavLink from "./NavLink";
+import { Trans } from "@lingui/macro";
+
+export default class ExternalToolListItem extends Component {
+  render() {
+    return (
+      <li className="ExpandCollapseList-item">
+        <div className="ExpandCollapseList-item-inner">
+          <div>
+            <span className="resource-icon">
+              <IconExternalLink />
+            </span>
+          </div>
+
+          <div style={{ flex: 1 }}>
+            <Link as={NavLink} to={`external/tool`}>
+              <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>
+            </Link>
+          </div>
+        </div>
+      </li>
+    );
+  }
+}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -15,6 +15,7 @@ import { Trans } from "@lingui/macro";
 
 import { getAssignmentSettingsHref } from "./utils.js";
 import AssociatedContentAssignmentListItem from "./AssociatedContentAssignmentListItem";
+import ExternalToolListItem from "./ExternalToolListItem";
 
 export default class ModulesList extends Component {
   render() {
@@ -135,6 +136,10 @@ export default class ModulesList extends Component {
                 item={item}
               />
             );
+          }
+
+          if (item.type === resourceTypes.EXTERNAL_TOOL) {
+            return <ExternalToolListItem key={index} item={item} />;
           }
 
           return (

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -96,13 +96,17 @@ export default class Resource extends Component {
     this.allItemsButton.click();
   };
 
+  makeNavigationButtonHrefFromModule = module =>
+    module.type === resourceTypes.EXTERNAL_TOOL
+      ? "/external/tool"
+      : `/resources/${module.identifierref || module.identifier}`;
+
   renderPreviousButton = previousItem => {
     return (
       <div className="previous-link">
         <Tooltip variant="inverse" tip={previousItem.title} placement="end">
           <Button
-            to={`/resources/${previousItem.identifierref ||
-              previousItem.identifier}`}
+            to={this.makeNavigationButtonHrefFromModule(previousItem)}
             variant="ghost"
             as={RouterLink}
             innerRef={this.setPreviousButton}
@@ -120,7 +124,7 @@ export default class Resource extends Component {
       <div className="next-link">
         <Tooltip variant="inverse" tip={nextItem.title} placement="start">
           <Button
-            to={`/resources/${nextItem.identifierref || nextItem.identifier}`}
+            to={this.makeNavigationButtonHrefFromModule(nextItem)}
             variant="ghost"
             as={RouterLink}
             innerRef={this.setNextButton}

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const resourceTypes = {
     "associatedcontent/imscc_xmlv1p1/learning-application-resource",
   BLTI: "imsbasiclti_xmlv1p0",
   DISCUSSION_TOPIC: "imsdt_xmlv1p1",
+  EXTERNAL_TOOL: "external_tool",
   QUESTION_BANK: "imsqti_xmlv1p2/imscc_xmlv1p1/question-bank",
   WEB_CONTENT: "webcontent",
   WEB_LINK: "imswl_xmlv1p1"
@@ -55,3 +56,14 @@ export const DOCUMENT_PREVIEW_EXTENSIONS_SUPPORTED = [
   "xls",
   "txt"
 ];
+
+export const moduleMetaContentTypes = {
+  ASSIGNMENT: "Assignment",
+  QUIZ: "Quizzes::Quiz",
+  ATTACHMENT: "Attachment",
+  WIKI_PAGE: "WikiPage",
+  DISCUSSION_TOPIC: "DiscussionTopic",
+  CONTEXT_MODULE_SUBHEADER: "ContextModuleSubHeade",
+  EXTERNAL_URL: "ExternalUrl",
+  CONTENT_EXTERNAL_TOOL: "ContextExternalTool"
+};

--- a/tests/test.content-nav.js
+++ b/tests/test.content-nav.js
@@ -28,7 +28,9 @@ test("Previous link on last page works", async t => {
   const previousButton = Selector("span")
     .withText("Previous")
     .parent("a");
-  const spinner = Selector(".DocumentPreview--loading");
+  const externalToolMessage = Selector("span").withText(
+    "External Tool Content Can't be Previewed"
+  );
 
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
@@ -37,7 +39,7 @@ test("Previous link on last page works", async t => {
   );
   await t.expect(nextButton.exists).notOk();
   await t.click(previousButton);
-  await t.expect(spinner.exists).ok();
+  await t.expect(externalToolMessage.exists).ok();
 });
 
 test("All Items link works", async t => {

--- a/tests/test.external-tools.js
+++ b/tests/test.external-tools.js
@@ -1,0 +1,28 @@
+import { Selector } from "testcafe";
+
+fixture`External Tool Items`
+  .page`http://localhost:5000/?manifest=${encodeURIComponent(
+  "http://localhost:5000/test-cartridges/course-1/imsmanifest.xml"
+)}#/`;
+
+test("External tools show up correctly in Module list", async t => {
+  const externalToolLink = Selector("a").withText(
+    "First Module AnalyTics Beta External Tool"
+  );
+  await t.expect(externalToolLink.exists).ok();
+});
+
+test("External tools links respond correctly when clicked", async t => {
+  const externalToolLink = Selector("a").withText(
+    "First Module AnalyTics Beta External Tool"
+  );
+  const externalToolMessage = Selector("span").withText(
+    "External Tool Content Can't be Previewed"
+  );
+  await t
+    .expect(externalToolLink.exists)
+    .ok()
+    .click(externalToolLink)
+    .expect(externalToolMessage.exists)
+    .ok();
+});


### PR DESCRIPTION
Fixes CM-599

Test Plan:
 - Preview a course that contains external tool items.
 - They show up correctly in the module view.
 - When you click an external tool item you are presented with a page that says external tool content cannot be previewed.