### PR TITLE
Fix: make pages nav count only count wiki pages

### DIFF
--- a/public/test-cartridges/course-1/course_settings/module_meta.xml
+++ b/public/test-cartridges/course-1/course_settings/module_meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<modules xmlns="http://canvas.instructure.com/xsd/cccv1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
+<modules xmlns="http://canvas.instructure.com/xsd/cccv1p0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
   <module identifier="i02ce3f13d96fb86be0bfcbecfc2e42ed">
     <title>First Module</title>
     <workflow_state>unpublished</workflow_state>
@@ -78,6 +79,15 @@
         <url>https://canvas-analytics-iad-prod.inscloudgate.net/lti_check_teacher_performance</url>
         <global_identifierref>138</global_identifierref>
         <position>8</position>
+        <new_tab>false</new_tab>
+        <indent>0</indent>
+      </item>
+      <item identifier="icaec87d897e6b152b5ea0279c20ff9e8">
+        <content_type>Attachment</content_type>
+        <workflow_state>active</workflow_state>
+        <title>The First Measured Century: 1930-1960 (60:00)</title>
+        <identifierref>ie51764b374b71d85aef92a2fa25368ef</identifierref>
+        <position>9</position>
         <new_tab>false</new_tab>
         <indent>0</indent>
       </item>

--- a/public/test-cartridges/course-1/imsmanifest.xml
+++ b/public/test-cartridges/course-1/imsmanifest.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest identifier="ife6c3152cbc3f055b596a033fad66b4c" xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imscp_v1p1" xmlns:lom="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/resource" xmlns:lomimscc="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/manifest" xmlns:cpx="http://www.imsglobal.org/xsd/imsccv1p3/imscp_extensionv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/resource http://www.imsglobal.org/profile/cc/ccv1p3/LOM/ccv1p3_lomresource_v1p0.xsd http://www.imsglobal.org/xsd/imsccv1p3/imscp_v1p1 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imscp_v1p2_v1p0.xsd http://ltsc.ieee.org/xsd/imsccv1p3/LOM/manifest http://www.imsglobal.org/profile/cc/ccv1p3/LOM/ccv1p3_lommanifest_v1p0.xsd http://www.imsglobal.org/xsd/imsccv1p3/imscp_extensionv1p2 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_cpextensionv1p2_v1p0.xsd">
+<manifest identifier="ife6c3152cbc3f055b596a033fad66b4c" 
+  xmlns="http://www.imsglobal.org/xsd/imsccv1p3/imscp_v1p1" 
+  xmlns:lom="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/resource" 
+  xmlns:lomimscc="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/manifest" 
+  xmlns:cpx="http://www.imsglobal.org/xsd/imsccv1p3/imscp_extensionv1p2" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ltsc.ieee.org/xsd/imsccv1p3/LOM/resource http://www.imsglobal.org/profile/cc/ccv1p3/LOM/ccv1p3_lomresource_v1p0.xsd http://www.imsglobal.org/xsd/imsccv1p3/imscp_v1p1 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_imscp_v1p2_v1p0.xsd http://ltsc.ieee.org/xsd/imsccv1p3/LOM/manifest http://www.imsglobal.org/profile/cc/ccv1p3/LOM/ccv1p3_lommanifest_v1p0.xsd http://www.imsglobal.org/xsd/imsccv1p3/imscp_extensionv1p2 http://www.imsglobal.org/profile/cc/ccv1p3/ccv1p3_cpextensionv1p2_v1p0.xsd">
   <metadata>
     <schema>IMS Common Cartridge</schema>
     <schemaversion>1.3.0</schemaversion>
@@ -61,6 +66,9 @@
           <item identifier="ib9e9d751c5934866aeee701374164321" identifierref="iaa4b4fdadec793530c31c58a249e0879">
             <title>Assignment with internal links</title>
           </item>
+          <item identifier="icaec87d897e6b152b5ea0279c20ff9e8" identifierref="ie51764b374b71d85aef92a2fa25368ef">
+            <title>The First Measured Century: 1930-1960 (60:00)</title>
+          </item>
         </item>
       </item>
     </organization>
@@ -74,6 +82,9 @@
       <file href="course_settings/media_tracks.xml"/>
       <file href="course_settings/external_viewers.xml" />
       <file href="course_settings/canvas_export.txt"/>
+    </resource>
+    <resource type="webcontent" identifier="ie51764b374b71d85aef92a2fa25368ef" href="web_resources/CourseFiles/_assoc/672C021605644FDFBEAC13BE37E326B2/The_First_Measured_Century__1930-1960__60_00_.html">
+      <file href="web_resources/CourseFiles/_assoc/672C021605644FDFBEAC13BE37E326B2/The_First_Measured_Century__1930-1960__60_00_.html"/>
     </resource>
     <resource identifier="i0c940bd995254e5f0bf694dc5aaea005" type="webcontent" href="wiki_content/first-module-wiki-page-1.html">
       <file href="wiki_content/first-module-wiki-page-1.html"/>

--- a/public/test-cartridges/course-1/web_resources/CourseFiles/_assoc/672C021605644FDFBEAC13BE37E326B2/The_First_Measured_Century__1930-1960__60_00_.html
+++ b/public/test-cartridges/course-1/web_resources/CourseFiles/_assoc/672C021605644FDFBEAC13BE37E326B2/The_First_Measured_Century__1930-1960__60_00_.html
@@ -1,0 +1,9 @@
+<p>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus quam nulla,
+  pretium condimentum lorem eget, congue facilisis metus. Donec interdum, eros
+  nec efficitur sollicitudin, elit mauris varius orci, eget accumsan risus augue
+  quis turpis. Morbi accumsan magna ut tempus laoreet. Integer maximus est a
+  urna feugiat, ut mattis magna luctus. Suspendisse ut auctor elit. Integer sit
+  amet dui arcu. Nullam non mollis eros. Sed consectetur, ex suscipit suscipit
+  egestas, tortor sapien ornare mi, sit amet ultrices purus ligula ut justo.
+</p>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,8 @@
 import {
   resourceTypes,
   submissionTypes,
-  moduleMetaContentTypes
+  moduleMetaContentTypes,
+  WIKI_CONTENT_HREF_PREFIX
 } from "./constants";
 import { i18n } from "./index";
 import { t } from "@lingui/macro";
@@ -157,10 +158,10 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     .filter(node => node.querySelector("file"))
     // needs filter to filter out dependencies
     .filter(node => {
-      const extension = getExtension(
-        node.querySelector("file").getAttribute("href")
+      const href = node.getAttribute("href");
+      return (
+        typeof href === "string" && href.includes(WIKI_CONTENT_HREF_PREFIX)
       );
-      return ["html", "htm"].includes(extension);
     });
   const fileResources = resources
     .filter(is(resourceTypes.WEB_CONTENT))

--- a/tests/test.content-nav.js
+++ b/tests/test.content-nav.js
@@ -32,11 +32,16 @@ test("Previous link on last page works", async t => {
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
       "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/iaa4b4fdadec793530c31c58a249e0879`
+    )}#/resources/ie51764b374b71d85aef92a2fa25368ef`
   );
   await t.expect(nextButton.exists).notOk();
   await t.click(previousButton);
-  await t.expect(Selector("h1").withText("photo.jpg").exists).ok();
+  await t
+    .expect(
+      Selector("h1").withText("Assignment with Internal and External Links")
+        .exists
+    )
+    .ok();
 });
 
 test("All Items link works", async t => {
@@ -48,4 +53,16 @@ test("All Items link works", async t => {
 
   await t.click(Selector("a").withText("All Items"));
   await t.expect(Selector("div").withText("First Module").exists).ok();
+});
+
+fixture`Content Navigation sidebar links`;
+
+test("Sidebar link for Pages displays correct number of wiki pages", async t => {
+  const pagesSidebarLink = Selector("a").withExactText("Pages (1)");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "http://localhost:5000/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+  await t.expect(pagesSidebarLink.exists).ok();
 });


### PR DESCRIPTION
By previewing this cartridge `?cartridge=https://s3.amazonaws.com/public-imscc/45b943dadf904bb0835df11e62030742.imscc#/pages` you can see that the nav shows `Pages (67)` while only displaying 2 page items in the list view. This pr adds the correct filtering to the nav so that `htm/html` aren't counted as page items just because of their file type. 

Test Plan:
 - Preview a cartridge that has wiki pages & `htm/html` file uploads.
 - The `htm/html` file uploads are not counted toward the Pages nav count.
 - The number of items in the Pages list view matches the Pages nav count. (ie. 2 Page items would show up as `Pages (2)` in the nav)