### PR TITLE
Fix: assignments have file entry in viewer

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -165,7 +165,13 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     });
   const fileResources = resources
     .filter(is(resourceTypes.WEB_CONTENT))
-    .filter(node => node.querySelector("file"));
+    .filter(node => node.querySelector("file"))
+    .filter(
+      node =>
+        typeof node.getAttribute("href") === "string" &&
+        node.getAttribute("href").startsWith("web_resources/")
+    );
+
   const assessmentResources = resources
     .filter(is(resourceTypes.ASSESSMENT_CONTENT))
     .filter(node => node.querySelector("file"));

--- a/tests/test.accessibility-workshop.js
+++ b/tests/test.accessibility-workshop.js
@@ -6,7 +6,7 @@ test("Pages", async t => {
   await t
     .click(Selector("a").withText("Ally: Accessibility Workshop"))
     .expect(Selector("a").withText("Pages").exists)
-    .ok()
+    .ok({ timeout: 20000 })
     .click(Selector("a").withText("Pages"))
     .expect(Selector("a").withText("The Time is Now").exists)
     .ok()
@@ -22,7 +22,7 @@ test("Substition token (IMS-CC-FILEBASE)", async t => {
   await t
     .click(Selector("a").withText("Ally: Accessibility Workshop"))
     .expect(Selector("a").withText("Pages").exists)
-    .ok()
+    .ok({ timeout: 20000 })
     .click(Selector("a").withText("Pages"))
     .expect(Selector("a").withText("The Time is Now").exists)
     .ok()
@@ -43,7 +43,7 @@ test("Substition token (WIKI_REFERENCE)", async t => {
   await t
     .click(Selector("a").withText("Ally: Accessibility Workshop"))
     .expect(Selector("a").withText("Pages"))
-    .ok()
+    .ok({ timeout: 20000 })
     .click(Selector("a").withText("Pages"))
     .expect(Selector("a").withText("The Time is Now"))
     .ok()
@@ -62,7 +62,7 @@ test("Discussions", async t => {
     .click(Selector("a").withText("Ally: Accessibility Workshop"))
     .click(Selector("a").withText("Discussions"))
     .expect(Selector("a").withText("Accessibility in your life").exists)
-    .ok()
+    .ok({ timeout: 20000 })
     .expect(Selector("a").withText("Your courses, Accessible").exists)
     .ok()
     .expect(Selector("a").withText(`Share your "Before" Courses`).exists)
@@ -75,7 +75,7 @@ test("Files", async t => {
   await t
     .click(Selector("a").withText("Ally: Accessibility Workshop"))
     .expect(Selector("a").withText("Files").exists)
-    .ok()
+    .ok({ timeout: 20000 })
     .click(Selector("a").withText("Files"))
     .expect(
       Selector("div").withText("web_resources/Ally Accessibility Checklist.pdf")

--- a/tests/test.files.js
+++ b/tests/test.files.js
@@ -1,0 +1,12 @@
+import { Selector } from "testcafe";
+
+fixture`File Items`.page`http://localhost:5000/?manifest=${encodeURIComponent(
+  "/test-cartridges/course-1/imsmanifest.xml"
+)}#/files`;
+
+test("Assignment items don't show up as files", async t => {
+  const assignmentFileItem = Selector("a").withText(
+    "i7aff7e807cbf2c3be5ca6fc0733ff0a8/first-module-assignment-1.html"
+  );
+  await t.expect(assignmentFileItem.exists).notOk();
+});


### PR DESCRIPTION
Fixes CM-640

Test Plan:
 - Preview a cartridge that has Assignments.
 - Verify that the Assignments do not show up in the Files section.

Additional:
 - Increased timeout on A11y Workshop tests.