### PR TITLE
External hyperlinks in RC open in a new tab

### DIFF
--- a/src/RichContent.js
+++ b/src/RichContent.js
@@ -116,6 +116,18 @@ export default class RichContent extends Component {
       );
     }
 
+    {
+      const links = Array.from(fragment.querySelectorAll("a[href]"));
+      await Promise.all(
+        links
+          .filter(link => link.host !== window.location.host)
+          .map(async link => {
+            link.setAttribute("target", `_blank`);
+            link.setAttribute("rel", "noopener noreferrer");
+          })
+      );
+    }
+
     const isCartridgeFile = img =>
       img.getAttribute("src") &&
       (img.getAttribute("src").indexOf(CC_FILE_PREFIX_OLD) > -1 ||


### PR DESCRIPTION
Closes CM-619

Test Plan:
 - Preview a resource that contains external hyperlinks
 - Click on them
 - They open up a new tab
 - Internal links do not open up a new tab