### PR TITLE
increase document preview iframe

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -177,6 +177,6 @@ h3 {
 
 .DocumentPreview iframe {
   width: 100%;
-  height: 400px;
+  height: 800px;
   border: 0 none;
 }


### PR DESCRIPTION
- testing in a post-deploy env revealed that
  400px was too small. Changed to 800px to
  match canvas-lms