### PR TITLE
Fix: Change nav button functionality (WIP)

### DIFF
--- a/src/AssessmentListItem.js
+++ b/src/AssessmentListItem.js
@@ -64,7 +64,13 @@ export default class AssessmentListItem extends Component {
           </span>
           <div style={{ flex: 1 }}>
             <div>
-              <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+              <Link
+                as={RouterLink}
+                to={{
+                  pathname: `resources/${this.props.identifier}`,
+                  state: { from: this.props.from }
+                }}
+              >
                 {this.state.title}
               </Link>
             </div>

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -58,6 +58,7 @@ export default class AssignmentListItem extends Component {
         description={this.state.workflowState}
         points={this.state.points}
         workflowState={this.state.workflowState}
+        from={this.props.from}
       />
     );
   }

--- a/src/AssignmentListItemBody.js
+++ b/src/AssignmentListItemBody.js
@@ -15,7 +15,13 @@ export default class AssignmentListItemBody extends PureComponent {
             <IconAssignment color={this.props.iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.props.title}
             </Link>
           </div>

--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -63,6 +63,7 @@ export default class AssociatedContentAssignmentListItem extends Component {
         description={this.state.workflowState}
         points={this.state.pointsPossible}
         workflowState={this.state.workflowState}
+        from={this.props.from}
       />
     );
   }

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -475,7 +475,7 @@ export default class CommonCartridge extends Component {
                         <Route
                           exact
                           path="/resources/:identifier"
-                          render={({ match }) => (
+                          render={({ match, location }) => (
                             <React.Fragment>
                               {this.activeNavLink === undefined &&
                                 !showcaseSingleResource &&
@@ -499,6 +499,7 @@ export default class CommonCartridge extends Component {
                                   this.state.resourceIdsByHrefMap
                                 }
                                 resourceMap={this.state.resourceMap}
+                                location={location}
                               />
                             </React.Fragment>
                           )}
@@ -614,15 +615,25 @@ export default class CommonCartridge extends Component {
                         <Route
                           exact
                           path="/course/navigation"
-                          render={({ match }) => (
-                            <CourseNavigationUnavailable />
+                          render={({ match, location }) => (
+                            <CourseNavigationUnavailable
+                              moduleItems={this.state.moduleItems}
+                              resourceMap={this.state.resourceMap}
+                              location={location}
+                            />
                           )}
                         />
 
                         <Route
                           exact
-                          path="/external/tool"
-                          render={({ match }) => <PreviewUnavailable />}
+                          path="/external/tool/:identifier"
+                          render={({ match, location }) => (
+                            <PreviewUnavailable
+                              moduleItems={this.state.moduleItems}
+                              identifier={match.params.identifier}
+                              location={location}
+                            />
+                          )}
                         />
                       </Switch>
 

--- a/src/DiscussionListItem.js
+++ b/src/DiscussionListItem.js
@@ -60,7 +60,13 @@ export default class DiscussionListItem extends Component {
           </span>
 
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.state.title}
             </Link>
           </div>

--- a/src/ExternalToolListItem.js
+++ b/src/ExternalToolListItem.js
@@ -16,7 +16,13 @@ export default class ExternalToolListItem extends Component {
           </div>
 
           <div style={{ flex: 1 }}>
-            <Link as={NavLink} to={`external/tool`}>
+            <Link
+              as={NavLink}
+              to={{
+                pathname: `external/tool/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>
             </Link>
           </div>

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -57,7 +57,13 @@ export default class FileListItem extends Component {
             <IconPaperclip color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.props.title ||
                 this.state.title.replace(/^(web_resources\/)/, "")}
             </Link>

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -3,7 +3,11 @@ import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import Link from "@instructure/ui-elements/lib/components/Link";
 
-import { resourceTypes, WIKI_CONTENT_HREF_PREFIX } from "./constants";
+import {
+  resourceTypes,
+  WIKI_CONTENT_HREF_PREFIX,
+  MODULE_LIST
+} from "./constants";
 import NavLink from "./NavLink";
 import AssignmentListItem from "./AssignmentListItem";
 import AssessmentListItem from "./AssessmentListItem";
@@ -49,6 +53,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -63,6 +68,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -81,6 +87,7 @@ export default class ModulesList extends Component {
                   item={item}
                   key={index}
                   src={this.props.src}
+                  from={MODULE_LIST}
                 />
               );
             }
@@ -96,6 +103,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -110,6 +118,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -124,6 +133,7 @@ export default class ModulesList extends Component {
                 metadata={item.metadata}
                 src={this.props.src}
                 title={item.title}
+                from={MODULE_LIST}
               />
             );
           }
@@ -134,12 +144,20 @@ export default class ModulesList extends Component {
                 key={index}
                 identifier={item.identifierref}
                 item={item}
+                from={MODULE_LIST}
               />
             );
           }
 
           if (item.type === resourceTypes.EXTERNAL_TOOL) {
-            return <ExternalToolListItem key={index} item={item} />;
+            return (
+              <ExternalToolListItem
+                key={index}
+                item={item}
+                identifier={item.identifierref}
+                from={MODULE_LIST}
+              />
+            );
           }
 
           return (

--- a/src/NavigationButton.js
+++ b/src/NavigationButton.js
@@ -1,0 +1,39 @@
+import React, { PureComponent } from "react";
+import Tooltip from "@instructure/ui-overlays/lib/components/Tooltip";
+import Button from "@instructure/ui-buttons/lib/components/Button";
+import { Link as RouterLink } from "react-router-dom";
+import { resourceTypes } from "./constants";
+
+export default class NavigationButton extends PureComponent {
+  makeNavigationButtonHrefFromModule = module =>
+    module.type === resourceTypes.EXTERNAL_TOOL
+      ? `/external/tool/${module.identifierref || module.identifier}`
+      : `/resources/${module.identifierref || module.identifier}`;
+
+  render() {
+    return (
+      <div className="navigation-link">
+        <Tooltip
+          variant="inverse"
+          tip={this.props.toItem.title}
+          placement="end"
+        >
+          <Button
+            to={{
+              pathname: this.makeNavigationButtonHrefFromModule(
+                this.props.toItem
+              ),
+              state: this.props.location.state
+            }}
+            variant="ghost"
+            as={RouterLink}
+            innerRef={this.setToItemButton}
+            onClick={this.handleToItemButtonPressed}
+          >
+            {this.props.navButtonText}
+          </Button>
+        </Tooltip>
+      </div>
+    );
+  }
+}

--- a/src/NavigationButtonContainer.js
+++ b/src/NavigationButtonContainer.js
@@ -1,0 +1,44 @@
+import React, { PureComponent } from "react";
+import Flex, { FlexItem } from "@instructure/ui-layout/lib/components/Flex";
+import NavigationButton from "./NavigationButton";
+import { I18n } from "@lingui/react";
+import { t } from "@lingui/macro";
+
+export default class NavigationButtonContainer extends PureComponent {
+  render() {
+    return (
+      <Flex margin="0 0 medium">
+        <FlexItem padding="small" width="14rem">
+          {this.props.buttonNavigationEnabled && this.props.previousItem && (
+            <I18n>
+              {({ i18n }) => (
+                <NavigationButton
+                  toItem={this.props.previousItem}
+                  location={this.props.location}
+                  navButtonText={i18n._(t`Previous`)}
+                />
+              )}
+            </I18n>
+          )}
+        </FlexItem>
+        <FlexItem padding="small" width="14rem" grow={true}>
+          <Flex justifyItems="end">
+            <FlexItem>
+              {this.props.buttonNavigationEnabled && this.props.nextItem && (
+                <I18n>
+                  {({ i18n }) => (
+                    <NavigationButton
+                      toItem={this.props.nextItem}
+                      location={this.props.location}
+                      navButtonText={i18n._(t`Next`)}
+                    />
+                  )}
+                </I18n>
+              )}
+            </FlexItem>
+          </Flex>
+        </FlexItem>
+      </Flex>
+    );
+  }
+}

--- a/src/PreviewUnavailable.js
+++ b/src/PreviewUnavailable.js
@@ -3,7 +3,7 @@ import Unavailable from "./Unavailable";
 import { I18n } from "@lingui/react";
 import { t } from "@lingui/macro";
 
-export default function PreviewUnavailable() {
+export default function PreviewUnavailable(props) {
   return (
     <I18n>
       {({ i18n }) => (
@@ -12,6 +12,9 @@ export default function PreviewUnavailable() {
           subHeading={i18n._(
             t`In order to use this resource in Canvas, the external tool must be installed.`
           )}
+          moduleItems={props.moduleItems}
+          identifier={props.identifier}
+          location={props.location}
         />
       )}
     </I18n>

--- a/src/ResourceUnavailable.js
+++ b/src/ResourceUnavailable.js
@@ -3,13 +3,16 @@ import Unavailable from "./Unavailable";
 import { I18n } from "@lingui/react";
 import { t } from "@lingui/macro";
 
-export default function ResourceUnavailable() {
+export default function ResourceUnavailable(props) {
   return (
     <I18n>
       {({ i18n }) => (
         <Unavailable
           heading={i18n._(t`Resource Unavailable`)}
           subHeading={i18n._(t`This resource is not included in the package.`)}
+          moduleItems={props.moduleItems}
+          identifier={props.identifier}
+          location={props.location}
         />
       )}
     </I18n>

--- a/src/Unavailable.js
+++ b/src/Unavailable.js
@@ -2,10 +2,28 @@ import React from "react";
 import noSignalTvIcon from "./images/no-signal-tv.svg";
 import View from "@instructure/ui-layout/lib/components/View";
 import Text from "@instructure/ui-elements/lib/components/Text";
+import { getPreviousAndNextItems, isButtonNavigationEnabled } from "./utils";
+import NavigationButtonContainer from "./NavigationButtonContainer";
 
 export default function Unavailable(props) {
+  const moduleItem = props.moduleItems.find(
+    moduleItem => moduleItem.identifierref === props.identifier
+  );
+  const [previousItem, nextItem] = getPreviousAndNextItems(
+    props.moduleItems,
+    moduleItem && moduleItem.href
+  );
+  const buttonNavigationEnabled = isButtonNavigationEnabled(props.location);
   return (
     <View as="div" textAlign="center">
+      {previousItem && nextItem && (
+        <NavigationButtonContainer
+          buttonNavigationEnabled={buttonNavigationEnabled}
+          previousItem={previousItem}
+          nextItem={nextItem}
+          location={props.location}
+        />
+      )}
       <View as="div">
         <img
           className="preview-not-available-icon"

--- a/src/WebLinkListItem.js
+++ b/src/WebLinkListItem.js
@@ -20,7 +20,13 @@ export default class WebLinkListItem extends Component {
 
           <div style={{ flex: 1 }}>
             {this.props.item.href && (
-              <Link as={NavLink} to={`resources/${this.props.identifier}`}>
+              <Link
+                as={NavLink}
+                to={{
+                  pathname: `resources/${this.props.identifier}`,
+                  state: { from: this.props.from }
+                }}
+              >
                 <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>
               </Link>
             )}

--- a/src/WikiContentListItem.js
+++ b/src/WikiContentListItem.js
@@ -59,7 +59,13 @@ export default class WikiContentListItem extends Component {
             <IconDocument color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.state.title || basename(this.props.href)}
             </Link>
           </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";
 export const WIKI_CONTENT_HREF_PREFIX = "wiki_content";
 export const ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX = /(^Assignment: )/;
+export const MODULE_LIST = "module_list";
 
 export const resourceTypes = {
   ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",

--- a/src/index.css
+++ b/src/index.css
@@ -180,3 +180,7 @@ h3 {
   height: 400px;
   border: 0 none;
 }
+
+.navigation-link {
+  float: left;
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,8 @@ import {
   resourceTypes,
   submissionTypes,
   moduleMetaContentTypes,
-  WIKI_CONTENT_HREF_PREFIX
+  WIKI_CONTENT_HREF_PREFIX,
+  MODULE_LIST
 } from "./constants";
 import { i18n } from "./index";
 import { t } from "@lingui/macro";
@@ -240,7 +241,8 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
               return {
                 title,
                 type: resourceTypes.EXTERNAL_TOOL,
-                href: "#/external/tool"
+                href: `#/external/tool/${identifierref}`,
+                identifierref
               };
             }
           }
@@ -357,4 +359,15 @@ export function getAssignmentListResources(resources) {
         }
       )
     }));
+}
+
+export function getPreviousAndNextItems(moduleItems, href) {
+  const currentIndex = moduleItems.findIndex(item => `${item.href}` === href);
+  const previousItem = currentIndex > -1 && moduleItems[currentIndex - 1];
+  const nextItem = currentIndex > -1 && moduleItems[currentIndex + 1];
+  return [previousItem, nextItem];
+}
+
+export function isButtonNavigationEnabled(location) {
+  return location && location.state && location.state.from === MODULE_LIST;
 }

--- a/tests/test.content-nav.js
+++ b/tests/test.content-nav.js
@@ -1,6 +1,145 @@
 import { Selector } from "testcafe";
 
-fixture`Content Navigation links (Next, Previous, Etc.)`;
+fixture`Content Navigation links (Next & Previous)`;
+
+test("Previous and Next buttons show up after navigating from Modules", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleQuiz1 = Selector("a").withText("First Module Quiz 1");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  await t
+    .click(firstModuleQuiz1)
+    .expect(nextButton.exists)
+    .ok()
+    .expect(previousButton.exists)
+    .ok();
+});
+
+test("Previous and Next buttons don't show up after navigating from Assignments", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleAssignment1 = Selector("a").withText(
+    "First Module Assignment 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/assignments`
+  );
+
+  await t
+    .click(firstModuleAssignment1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Pages", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleWikiPage1 = Selector("a").withText(
+    "First Module Wiki Page 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/pages`
+  );
+
+  await t
+    .click(firstModuleWikiPage1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Discussions", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleDiscussion1 = Selector("a").withText(
+    "First Module Discussion 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/discussions`
+  );
+
+  await t
+    .click(firstModuleDiscussion1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+// NOTE: This test will need to be changed when https://github.com/instructure/common-cartridge-viewer/pull/71 gets merged
+test("Previous and Next buttons don't show up after navigating from Assessments", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleQuiz1 = Selector("a").withText("First Module Quiz 1");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/assessments`
+  );
+
+  await t
+    .click(firstModuleQuiz1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Files", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const photoJpg = Selector("a").withText("photo.jpg");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/files`
+  );
+
+  await t
+    .click(photoJpg)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
 
 test("Next link on first page works", async t => {
   const nextButton = Selector("span")
@@ -10,12 +149,13 @@ test("Next link on first page works", async t => {
     .withText("Previous")
     .parent("a");
   const titleH1 = Selector("h1");
-
+  const firstPageLink = Selector("a").withText("First Module Assignment 1");
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
       "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/i7aff7e807cbf2c3be5ca6fc0733ff0a8`
+    )}#/`
   );
+  await t.click(firstPageLink);
   await t.expect(previousButton.exists).notOk();
   await t.click(nextButton);
   await t.expect(titleH1.textContent).contains("First Module Quiz 1");
@@ -28,12 +168,15 @@ test("Previous link on last page works", async t => {
   const previousButton = Selector("span")
     .withText("Previous")
     .parent("a");
-
+  const lastPageLink = Selector("a").withText(
+    "The First Measured Century: 1930-1960 (60:00)"
+  );
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
       "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/ie51764b374b71d85aef92a2fa25368ef`
+    )}#/`
   );
+  await t.click(lastPageLink);
   await t.expect(nextButton.exists).notOk();
   await t.click(previousButton);
   await t
@@ -42,17 +185,6 @@ test("Previous link on last page works", async t => {
         .exists
     )
     .ok();
-});
-
-test("All Items link works", async t => {
-  await t.navigateTo(
-    `http://localhost:5000/?manifest=${encodeURIComponent(
-      "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/i694d024f7e7bb0de4335817c9d4649f1`
-  );
-
-  await t.click(Selector("a").withText("All Items"));
-  await t.expect(Selector("div").withText("First Module").exists).ok();
 });
 
 fixture`Content Navigation sidebar links`;


### PR DESCRIPTION
Fixes CM-644

Changes Previous, Next, and All Items buttons functionality to the following:
1. All Items button is removed completely.
2. Previous & Next buttons will only show up if the user navigates from the Modules list view.

Test Plan:
 - Preview a course that has a Module list with a variety of resource types.
 - Clicking on resources from the Module list view allows you to navigate via the Previous & Next buttons.
 - Clicking on resources from any other list view does not allow resource navigation via Previous & Next.