### PR TITLE
puts ModulesList inside a <ul>

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -456,16 +456,18 @@ export default class CommonCartridge extends Component {
                               ) : (
                                 <React.Fragment>
                                   {this.setActiveNavLink("/")}
-                                  <ModulesList
-                                    getTextByPath={this.getTextByPath}
-                                    associatedContentAssignmentHrefsSet={
-                                      this.state
-                                        .associatedContentAssignmentHrefsSet
-                                    }
-                                    moduleItems={this.state.moduleItems}
-                                    modules={this.state.modules}
-                                    match={match}
-                                  />
+                                  <ul>
+                                    <ModulesList
+                                      getTextByPath={this.getTextByPath}
+                                      associatedContentAssignmentHrefsSet={
+                                        this.state
+                                          .associatedContentAssignmentHrefsSet
+                                      }
+                                      moduleItems={this.state.moduleItems}
+                                      modules={this.state.modules}
+                                      match={match}
+                                    />
+                                  </ul>
                                 </React.Fragment>
                               )}
                             </React.Fragment>

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -443,7 +443,6 @@ export default class CommonCartridge extends Component {
                                 </React.Fragment>
                               ) : (
                                 <React.Fragment>
-                                  {this.setActiveNavLink("/")}
                                   <ul>
                                     <ModulesList
                                       getTextByPath={this.getTextByPath}


### PR DESCRIPTION
test plan:
- view a modules index in the viewer
- run axe chrome extension
- it no longer reports
- li not in a ul violation