### PR TITLE
Fix: Change nav button functionality

### DIFF
--- a/src/AssessmentListItem.js
+++ b/src/AssessmentListItem.js
@@ -64,7 +64,13 @@ export default class AssessmentListItem extends Component {
           </span>
           <div style={{ flex: 1 }}>
             <div>
-              <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+              <Link
+                as={RouterLink}
+                to={{
+                  pathname: `resources/${this.props.identifier}`,
+                  state: { from: this.props.from }
+                }}
+              >
                 {this.state.title}
               </Link>
             </div>

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -58,6 +58,7 @@ export default class AssignmentListItem extends Component {
         description={this.state.workflowState}
         points={this.state.points}
         workflowState={this.state.workflowState}
+        from={this.props.from}
       />
     );
   }

--- a/src/AssignmentListItemBody.js
+++ b/src/AssignmentListItemBody.js
@@ -15,7 +15,13 @@ export default class AssignmentListItemBody extends PureComponent {
             <IconAssignment color={this.props.iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.props.title}
             </Link>
           </div>

--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -63,6 +63,7 @@ export default class AssociatedContentAssignmentListItem extends Component {
         description={this.state.workflowState}
         points={this.state.pointsPossible}
         workflowState={this.state.workflowState}
+        from={this.props.from}
       />
     );
   }

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -34,7 +34,6 @@ import waitingWristWatch from "./images/waiting-wrist-watch.svg";
 import { I18n } from "@lingui/react";
 import { Trans, t } from "@lingui/macro";
 import CourseNavigationUnavailable from "./CourseNavigationUnavailable";
-import PreviewUnavailable from "./PreviewUnavailable";
 import Unavailable from "./Unavailable";
 
 // https://www.imsglobal.org/cc/ccv1p1/imscc_profilev1p1-Implementation.html
@@ -182,10 +181,6 @@ export default class CommonCartridge extends Component {
 
   handleLoadProgress = event => {
     this.setState({ loadProgress: event });
-  };
-
-  setActiveNavLink = link => {
-    this.activeNavLink = link;
   };
 
   getExternalViewers = async resourceIdsByHrefMap => {
@@ -408,7 +403,6 @@ export default class CommonCartridge extends Component {
                             <React.Fragment>
                               {showcaseSingleResource !== null ? (
                                 <React.Fragment>
-                                  {this.setActiveNavLink(null)}
                                   <Resource
                                     getTextByPath={this.getTextByPath}
                                     externalViewer={this.state.externalViewers.get(
@@ -429,7 +423,6 @@ export default class CommonCartridge extends Component {
                                 </React.Fragment>
                               ) : this.state.showcaseResources.length === 1 ? (
                                 <React.Fragment>
-                                  {this.setActiveNavLink("/")}
                                   <Resource
                                     externalViewer={this.state.externalViewers.get(
                                       this.state.showcaseResources[0].getAttribute(
@@ -446,12 +439,10 @@ export default class CommonCartridge extends Component {
                                     resourceIdsByHrefMap={
                                       this.state.resourceIdsByHrefMap
                                     }
-                                    allItemsPath={this.activeNavLink}
                                   />
                                 </React.Fragment>
                               ) : (
                                 <React.Fragment>
-                                  {this.setActiveNavLink("/")}
                                   <ModulesList
                                     getTextByPath={this.getTextByPath}
                                     associatedContentAssignmentHrefsSet={
@@ -471,13 +462,9 @@ export default class CommonCartridge extends Component {
                         <Route
                           exact
                           path="/resources/:identifier"
-                          render={({ match }) => (
+                          render={({ match, location }) => (
                             <React.Fragment>
-                              {this.activeNavLink === undefined &&
-                                !showcaseSingleResource &&
-                                this.setActiveNavLink("/")}
                               <Resource
-                                allItemsPath={this.activeNavLink}
                                 basepath={this.state.basepath}
                                 externalViewers={this.state.externalViewers}
                                 externalViewer={this.state.externalViewers.get(
@@ -496,6 +483,7 @@ export default class CommonCartridge extends Component {
                                   this.state.resourceIdsByHrefMap
                                 }
                                 resourceMap={this.state.resourceMap}
+                                location={location}
                               />
                             </React.Fragment>
                           )}
@@ -506,7 +494,6 @@ export default class CommonCartridge extends Component {
                           path="/modules/:module"
                           render={({ match }) => (
                             <React.Fragment>
-                              {this.setActiveNavLink("/")}
                               <ModulesList
                                 getTextByPath={this.getTextByPath}
                                 associatedContentAssignmentHrefsSet={
@@ -525,7 +512,6 @@ export default class CommonCartridge extends Component {
                           path="/quizzes"
                           render={({ match }) => (
                             <React.Fragment>
-                              {this.setActiveNavLink("/quizzes")}
                               <AssessmentList
                                 getTextByPath={this.getTextByPath}
                                 moduleItems={this.state.moduleItems}
@@ -541,7 +527,6 @@ export default class CommonCartridge extends Component {
                           path="/pages"
                           render={({ match }) => (
                             <React.Fragment>
-                              {this.setActiveNavLink("/pages")}
                               <WikiContentList
                                 getTextByPath={this.getTextByPath}
                                 moduleItems={this.state.moduleItems}
@@ -557,7 +542,6 @@ export default class CommonCartridge extends Component {
                           path="/discussions"
                           render={({ match }) => (
                             <React.Fragment>
-                              {this.setActiveNavLink("/discussions")}
                               <DiscussionList
                                 getTextByPath={this.getTextByPath}
                                 moduleItems={this.state.moduleItems}
@@ -573,7 +557,6 @@ export default class CommonCartridge extends Component {
                           path="/files"
                           render={({ match }) => (
                             <React.Fragment>
-                              {this.setActiveNavLink("/files")}
                               <FileList
                                 resources={this.state.fileResources}
                                 moduleItems={this.state.moduleItems}
@@ -588,7 +571,6 @@ export default class CommonCartridge extends Component {
                           path="/assignments"
                           render={({ match }) => (
                             <React.Fragment>
-                              {this.setActiveNavLink("/assignments")}
                               <AssignmentList
                                 getTextByPath={this.getTextByPath}
                                 moduleItems={this.state.moduleItems}
@@ -618,8 +600,32 @@ export default class CommonCartridge extends Component {
 
                         <Route
                           exact
-                          path="/external/tool"
-                          render={({ match }) => <PreviewUnavailable />}
+                          path="/external/tool/:identifier"
+                          render={({ match, location }) => (
+                            <React.Fragment>
+                              <Resource
+                                basepath={this.state.basepath}
+                                externalViewers={this.state.externalViewers}
+                                externalViewer={this.state.externalViewers.get(
+                                  match.params.identifier
+                                )}
+                                getBlobByPath={this.getBlobByPath}
+                                getTextByPath={this.getTextByPath}
+                                getUrlForPath={this.getUrlForPath}
+                                identifier={match.params.identifier}
+                                isCartridgeRemotelyExpanded={
+                                  this.state.isCartridgeRemotelyExpanded
+                                }
+                                moduleItems={this.state.moduleItems}
+                                modules={this.state.modules}
+                                resourceIdsByHrefMap={
+                                  this.state.resourceIdsByHrefMap
+                                }
+                                resourceMap={this.state.resourceMap}
+                                location={location}
+                              />
+                            </React.Fragment>
+                          )}
                         />
                       </Switch>
 

--- a/src/DiscussionListItem.js
+++ b/src/DiscussionListItem.js
@@ -60,7 +60,13 @@ export default class DiscussionListItem extends Component {
           </span>
 
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.state.title}
             </Link>
           </div>

--- a/src/ExternalToolListItem.js
+++ b/src/ExternalToolListItem.js
@@ -16,7 +16,13 @@ export default class ExternalToolListItem extends Component {
           </div>
 
           <div style={{ flex: 1 }}>
-            <Link as={NavLink} to={`external/tool`}>
+            <Link
+              as={NavLink}
+              to={{
+                pathname: `external/tool/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>
             </Link>
           </div>

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -57,7 +57,13 @@ export default class FileListItem extends Component {
             <IconPaperclip color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.props.title ||
                 this.state.title.replace(/^(web_resources\/)/, "")}
             </Link>

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -3,7 +3,11 @@ import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import Link from "@instructure/ui-elements/lib/components/Link";
 
-import { resourceTypes, WIKI_CONTENT_HREF_PREFIX } from "./constants";
+import {
+  resourceTypes,
+  WIKI_CONTENT_HREF_PREFIX,
+  MODULE_LIST
+} from "./constants";
 import NavLink from "./NavLink";
 import AssignmentListItem from "./AssignmentListItem";
 import AssessmentListItem from "./AssessmentListItem";
@@ -49,6 +53,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -63,6 +68,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -81,6 +87,7 @@ export default class ModulesList extends Component {
                   item={item}
                   key={index}
                   src={this.props.src}
+                  from={MODULE_LIST}
                 />
               );
             }
@@ -96,6 +103,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -110,6 +118,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
+                from={MODULE_LIST}
               />
             );
           }
@@ -124,6 +133,7 @@ export default class ModulesList extends Component {
                 metadata={item.metadata}
                 src={this.props.src}
                 title={item.title}
+                from={MODULE_LIST}
               />
             );
           }
@@ -134,12 +144,20 @@ export default class ModulesList extends Component {
                 key={index}
                 identifier={item.identifierref}
                 item={item}
+                from={MODULE_LIST}
               />
             );
           }
 
           if (item.type === resourceTypes.EXTERNAL_TOOL) {
-            return <ExternalToolListItem key={index} item={item} />;
+            return (
+              <ExternalToolListItem
+                key={index}
+                item={item}
+                identifier={item.identifierref}
+                from={MODULE_LIST}
+              />
+            );
           }
 
           return (

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -1,10 +1,10 @@
 import { basename } from "path";
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import {
   resourceTypes,
   DOCUMENT_PREVIEW_EXTENSIONS_SUPPORTED,
-  NOTORIOUS_EXTENSIONS_SUPPORTED
+  NOTORIOUS_EXTENSIONS_SUPPORTED,
+  MODULE_LIST
 } from "./constants";
 import { Link as RouterLink } from "react-router-dom";
 import { saveAs } from "file-saver";
@@ -25,12 +25,9 @@ import { getExtension, getResourceHref } from "./utils";
 import { Trans } from "@lingui/macro";
 import EmbeddedPreview from "./EmbeddedPreview";
 import ResourceUnavailable from "./ResourceUnavailable";
+import PreviewUnavailable from "./PreviewUnavailable";
 
 export default class Resource extends Component {
-  static propTypes = {
-    allItemsPath: PropTypes.string
-  };
-
   constructor(props) {
     super(props);
     this.state = {
@@ -81,10 +78,6 @@ export default class Resource extends Component {
     this.previousButton = node;
   };
 
-  setAllItemsButton = node => {
-    this.allItemsButton = node;
-  };
-
   handleNextButtonPressed = () => {
     this.nextButton && this.nextButton.click();
   };
@@ -93,13 +86,9 @@ export default class Resource extends Component {
     this.previousButton && this.previousButton.click();
   };
 
-  handleAllItemsButtonPressed = () => {
-    this.allItemsButton.click();
-  };
-
   makeNavigationButtonHrefFromModule = module =>
     module.type === resourceTypes.EXTERNAL_TOOL
-      ? "/external/tool"
+      ? `/external/tool/${module.identifierref || module.identifier}`
       : `/resources/${module.identifierref || module.identifier}`;
 
   renderPreviousButton = previousItem => {
@@ -107,7 +96,10 @@ export default class Resource extends Component {
       <div className="previous-link">
         <Tooltip variant="inverse" tip={previousItem.title} placement="end">
           <Button
-            to={this.makeNavigationButtonHrefFromModule(previousItem)}
+            to={{
+              pathname: this.makeNavigationButtonHrefFromModule(previousItem),
+              state: this.props.location.state
+            }}
             variant="ghost"
             as={RouterLink}
             innerRef={this.setPreviousButton}
@@ -125,7 +117,10 @@ export default class Resource extends Component {
       <div className="next-link">
         <Tooltip variant="inverse" tip={nextItem.title} placement="start">
           <Button
-            to={this.makeNavigationButtonHrefFromModule(nextItem)}
+            to={{
+              pathname: this.makeNavigationButtonHrefFromModule(nextItem),
+              state: this.props.location.state
+            }}
             variant="ghost"
             as={RouterLink}
             innerRef={this.setNextButton}
@@ -135,22 +130,6 @@ export default class Resource extends Component {
           </Button>
         </Tooltip>
       </div>
-    );
-  };
-
-  renderAllItemsButton = () => {
-    return (
-      <Tooltip variant="inverse" tip="All Items" placement="bottom">
-        <Button
-          to={this.props.allItemsPath}
-          variant="ghost"
-          as={RouterLink}
-          innerRef={this.setAllItemsButton}
-          onClick={this.handleAllItemsButtonPressed}
-        >
-          <Trans>All Items</Trans>
-        </Button>
-      </Tooltip>
     );
   };
 
@@ -293,43 +272,57 @@ export default class Resource extends Component {
     return componentToRender;
   };
 
-  render() {
-    let resource = this.props.resourceMap.get(this.props.identifier);
-    const { moduleItems } = this.props;
-
-    if (resource == null) {
-      return <ResourceUnavailable />;
-    }
-
+  deriveResourceHref = resource => {
     if (resource.getAttribute("identifierref") != null) {
       resource = this.props.resourceMap.get(
         resource.getAttribute("identifierref")
       );
     }
 
-    const href = getResourceHref(resource);
+    return getResourceHref(resource);
+  };
+
+  render() {
+    let resource = this.props.resourceMap.get(this.props.identifier);
+    const { moduleItems } = this.props;
+    const isExternalToolPath =
+      this.props.location &&
+      this.props.location.pathname &&
+      this.props.location.pathname.startsWith("/external/tool");
+    const moduleItem = this.props.moduleItems.find(
+      moduleItem => moduleItem.identifierref === this.props.identifier
+    );
+
+    const isValidExternalToolResource =
+      isExternalToolPath && moduleItem !== undefined;
+
+    if (resource == null && isValidExternalToolResource === false) {
+      return <ResourceUnavailable />;
+    }
+
+    const href = resource ? this.deriveResourceHref(resource) : moduleItem.href;
     const currentIndex = moduleItems.findIndex(item => `${item.href}` === href);
     const previousItem = currentIndex > -1 && moduleItems[currentIndex - 1];
     const nextItem = currentIndex > -1 && moduleItems[currentIndex + 1];
-
+    const navigationButtonsEnabled =
+      this.props.location &&
+      this.props.location.state &&
+      this.props.location.state.from === MODULE_LIST;
     return (
       <React.Fragment>
         <div>
           <Flex margin="0 0 medium">
             <FlexItem padding="small" width="14rem">
-              {previousItem && this.renderPreviousButton(previousItem)}
+              {navigationButtonsEnabled &&
+                previousItem &&
+                this.renderPreviousButton(previousItem)}
             </FlexItem>
-            <FlexItem padding="small" grow={true} align="center">
-              <Flex justifyItems="center">
-                <FlexItem>
-                  {this.props.allItemsPath && this.renderAllItemsButton()}
-                </FlexItem>
-              </Flex>
-            </FlexItem>
-            <FlexItem padding="small" width="14rem">
+            <FlexItem padding="small" width="14rem" grow={true}>
               <Flex justifyItems="end">
                 <FlexItem>
-                  {nextItem && this.renderNextButton(nextItem)}
+                  {navigationButtonsEnabled &&
+                    nextItem &&
+                    this.renderNextButton(nextItem)}
                 </FlexItem>
               </Flex>
             </FlexItem>
@@ -340,7 +333,11 @@ export default class Resource extends Component {
             clear: "both"
           }}
         >
-          {this.renderResourceDocument(resource)}
+          {isValidExternalToolResource ? (
+            <PreviewUnavailable />
+          ) : (
+            this.renderResourceDocument(resource)
+          )}
         </div>
       </React.Fragment>
     );

--- a/src/WebLinkListItem.js
+++ b/src/WebLinkListItem.js
@@ -20,7 +20,13 @@ export default class WebLinkListItem extends Component {
 
           <div style={{ flex: 1 }}>
             {this.props.item.href && (
-              <Link as={NavLink} to={`resources/${this.props.identifier}`}>
+              <Link
+                as={NavLink}
+                to={{
+                  pathname: `resources/${this.props.identifier}`,
+                  state: { from: this.props.from }
+                }}
+              >
                 <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>
               </Link>
             )}

--- a/src/WikiContentListItem.js
+++ b/src/WikiContentListItem.js
@@ -59,7 +59,13 @@ export default class WikiContentListItem extends Component {
             <IconDocument color={iconColor} />
           </span>
           <div style={{ flex: 1 }}>
-            <Link as={RouterLink} to={`resources/${this.props.identifier}`}>
+            <Link
+              as={RouterLink}
+              to={{
+                pathname: `resources/${this.props.identifier}`,
+                state: { from: this.props.from }
+              }}
+            >
               {this.state.title || basename(this.props.href)}
             </Link>
           </div>

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,7 @@ export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";
 export const WIKI_CONTENT_HREF_PREFIX = "wiki_content";
 export const ASSOCIATED_CONTENT_ASSIGNMENT_TITLE_PREFIX_REGEX = /(^Assignment: )/;
+export const MODULE_LIST = "module_list";
 
 export const resourceTypes = {
   ASSESSMENT_CONTENT: "imsqti_xmlv1p2/imscc_xmlv1p1/assessment",

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,7 +240,8 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
               return {
                 title,
                 type: resourceTypes.EXTERNAL_TOOL,
-                href: "#/external/tool"
+                href: `#/external/tool/${identifierref}`,
+                identifierref
               };
             }
           }

--- a/tests/test.content-nav.js
+++ b/tests/test.content-nav.js
@@ -1,6 +1,187 @@
 import { Selector } from "testcafe";
 
-fixture`Content Navigation links (Next, Previous, Etc.)`;
+fixture`Content Navigation links (Next & Previous)`;
+
+test("Previous and Next buttons show up after navigating from Modules", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleQuiz1 = Selector("a").withText("First Module Quiz 1");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  await t
+    .click(firstModuleQuiz1)
+    .expect(nextButton.exists)
+    .ok()
+    .expect(previousButton.exists)
+    .ok();
+});
+
+test("Previous and Next work with external tool items", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const externalToolLink = Selector("a").withText(
+    "First Module AnalyTics Beta External Tool"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  await t
+    .click(externalToolLink)
+    .expect(nextButton.exists)
+    .ok()
+    .expect(previousButton.exists)
+    .ok()
+    .click(nextButton)
+    .expect(Selector("h1").withText("photo.jpg").exists)
+    .ok();
+
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  await t
+    .click(externalToolLink)
+    .expect(nextButton.exists)
+    .ok()
+    .expect(previousButton.exists)
+    .ok()
+    .click(previousButton)
+    .expect(Selector("div").withAttribute("data-ui-testable", "Spinner").exists)
+    .ok();
+});
+
+test("Previous and Next buttons don't show up after navigating from Assignments", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleAssignment1 = Selector("a").withText(
+    "First Module Assignment 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/assignments`
+  );
+
+  await t
+    .click(firstModuleAssignment1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Pages", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleWikiPage1 = Selector("a").withText(
+    "First Module Wiki Page 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/pages`
+  );
+
+  await t
+    .click(firstModuleWikiPage1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Discussions", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleDiscussion1 = Selector("a").withText(
+    "First Module Discussion 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/discussions`
+  );
+
+  await t
+    .click(firstModuleDiscussion1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Quizzes", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleQuiz1 = Selector("a").withText("First Module Quiz 1");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/quizzes`
+  );
+
+  await t
+    .click(firstModuleQuiz1)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
+
+test("Previous and Next buttons don't show up after navigating from Files", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const photoJpg = Selector("a").withText("photo.jpg");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/files`
+  );
+
+  await t
+    .click(photoJpg)
+    .expect(nextButton.exists)
+    .notOk()
+    .expect(previousButton.exists)
+    .notOk();
+});
 
 test("Next link on first page works", async t => {
   const nextButton = Selector("span")
@@ -10,12 +191,14 @@ test("Next link on first page works", async t => {
     .withText("Previous")
     .parent("a");
   const titleH1 = Selector("h1");
+  const firstPageLink = Selector("a").withText("First Module Assignment 1");
 
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
       "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/i7aff7e807cbf2c3be5ca6fc0733ff0a8`
+    )}#/`
   );
+  await t.click(firstPageLink);
   await t.expect(previousButton.exists).notOk();
   await t.click(nextButton);
   await t.expect(titleH1.textContent).contains("First Module Quiz 1");
@@ -28,12 +211,16 @@ test("Previous link on last page works", async t => {
   const previousButton = Selector("span")
     .withText("Previous")
     .parent("a");
+  const lastPageLink = Selector("a").withText(
+    "The First Measured Century: 1930-1960 (60:00)"
+  );
 
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
       "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/ie51764b374b71d85aef92a2fa25368ef`
+    )}#/`
   );
+  await t.click(lastPageLink);
   await t.expect(nextButton.exists).notOk();
   await t.click(previousButton);
   await t
@@ -42,17 +229,6 @@ test("Previous link on last page works", async t => {
         .exists
     )
     .ok();
-});
-
-test("All Items link works", async t => {
-  await t.navigateTo(
-    `http://localhost:5000/?manifest=${encodeURIComponent(
-      "/test-cartridges/course-1/imsmanifest.xml"
-    )}#/resources/i694d024f7e7bb0de4335817c9d4649f1`
-  );
-
-  await t.click(Selector("a").withText("All Items"));
-  await t.expect(Selector("div").withText("First Module").exists).ok();
 });
 
 fixture`Content Navigation sidebar links`;

--- a/tests/test.quizzes-types.js
+++ b/tests/test.quizzes-types.js
@@ -3,7 +3,7 @@ import { Selector } from "testcafe";
 fixture`Quiz with all question types`
   .page`http://localhost:5000/?manifest=/test-cartridges/all-question-types/imsmanifest.xml#/`;
 
-test("Resourde loads as quiz", async t => {
+test("Resource loads as quiz", async t => {
   await t.expect(Selector(".resource-label").withText("QUIZ").exists).ok();
   await t.expect(Selector(".MenuItem").withText("Quizzes (1)").exists).ok();
 });


### PR DESCRIPTION
Fixes CM-644
Fixes CM-609

Changes Previous, Next, and All Items buttons functionality to the following:
1. All Items button is removed completely.
2. Previous & Next buttons will only show up if the user navigates from the Modules list view.

Test Plan:
 - Preview a course that has a Module list with a variety of resource types.
 - Clicking on resources from the Module list view allows you to navigate via the Previous & Next buttons.
 - Clicking on resources from any other list view does not allow resource navigation via Previous & Next.