### PR TITLE
A11y: support high-contast mode

### DIFF
--- a/src/high-contrast.css
+++ b/src/high-contrast.css
@@ -1,0 +1,6 @@
+.MenuItem.active,
+.MenuItem:active {
+  color: #0770a3;
+  border-left: 3px solid #0770a3;
+  text-decoration: underline;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -43,8 +43,8 @@ body {
 
 .MenuItem.active,
 .MenuItem:active {
-  color: #398ddc;
-  border-left: 3px solid #398ddc;
+  color: #008ee2;
+  border-left: 3px solid #008ee2;
 }
 
 /* temporary */

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ import "whatwg-fetch";
 
 import React from "react";
 import ReactDOM from "react-dom";
-import "@instructure/ui-themes/lib/canvas";
+import theme from "@instructure/ui-themes/lib/canvas";
+import highContrastTheme from "@instructure/ui-themes/lib/canvas/high-contrast";
 import "./index.css";
 import App from "./App";
 import registerServiceWorker from "./registerServiceWorker";
@@ -19,6 +20,16 @@ const queryString = require("query-string-es5"); // has issue with module import
 const parsedQueryString = queryString.parse(window.location.search);
 
 export const i18n = setupI18n({ language: "en", catalogs: catalogs });
+
+const highContrastEnabled =
+  typeof parsedQueryString["high-contrast"] !== "undefined";
+
+if (highContrastEnabled) {
+  highContrastTheme.use();
+  import("./high-contrast.css");
+} else {
+  theme.use();
+}
 
 ReactDOM.render(
   <I18nProvider i18n={i18n}>

--- a/tests/test.a11y.js
+++ b/tests/test.a11y.js
@@ -1,0 +1,65 @@
+import { Selector } from "testcafe";
+
+fixture`A11y requirements`;
+
+test("High-contrast style support", async t => {
+  const NORMAL_THEME_LINK_RGB = "rgb(0, 142, 226)";
+  const HIGH_CONTRAST_THEME_LINK_RGB = "rgb(7, 112, 163)";
+
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+  const normalThemeModuleLink = Selector("a").withText(
+    "First Module Assignment 1"
+  );
+  const normalThemeNavigationLink = Selector("a").withText("Modules (1)");
+
+  await t
+    .expect(normalThemeModuleLink.exists)
+    .ok()
+    .expect(normalThemeNavigationLink.exists)
+    .ok();
+
+  const normalThemeModuleLinkSnapshot = await normalThemeModuleLink();
+  const normalThemeNavigationLinkSnapshot = await normalThemeNavigationLink();
+
+  await t
+    .expect(normalThemeModuleLinkSnapshot.style.color)
+    .eql(
+      NORMAL_THEME_LINK_RGB,
+      "Normal contrast module links display proper color"
+    )
+    .expect(normalThemeNavigationLinkSnapshot.style.color)
+    .eql(
+      NORMAL_THEME_LINK_RGB,
+      "Normal contrast navigation links display proper color"
+    );
+
+  await t.navigateTo(
+    `http://localhost:5000/?high-contrast&manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  const highContrastThemeModuleLink = Selector("a").withText(
+    "First Module Assignment 1"
+  );
+  const highContrastThemeNavigationLink = Selector("a").withText("Modules (1)");
+
+  const highContrastThemeModuleLinkSnapshot = await highContrastThemeModuleLink();
+  const highContrastThemeNavigationLinkSnapshot = await highContrastThemeNavigationLink();
+
+  await t
+    .expect(highContrastThemeModuleLinkSnapshot.style.color)
+    .eql(
+      HIGH_CONTRAST_THEME_LINK_RGB,
+      "High contrast module links display proper color"
+    )
+    .expect(highContrastThemeNavigationLinkSnapshot.style.color)
+    .eql(
+      HIGH_CONTRAST_THEME_LINK_RGB,
+      "High contrast navigation links display proper color"
+    );
+});


### PR DESCRIPTION
Refs CM-649

This pr handles enabling high-contrast mode in the viewer. It will check the query string for a `high-contrast` parameter and, if present, enable the high-contrast theme.