### PR TITLE
Focus on <main> when link "clicked" with keyboard

### DIFF
--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -129,7 +129,7 @@ export default class Assessment extends Component {
                   <GridCol width={5}>
                     {item.options &&
                       item.options.map(option => (
-                        <Grid vAlign="middle" colSpacing="none">
+                        <Grid key={option.id} vAlign="middle" colSpacing="none">
                           <GridRow>
                             <GridCol width={1}>
                               {option.valid && (

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -64,7 +64,22 @@ export default class CommonCartridge extends Component {
     };
   }
 
+  handleDocumentKeydown = event => {
+    if (event.code !== "Enter") return;
+    const wasLinkTriggered = event.target.nodeName === "A";
+    if (wasLinkTriggered === false) return;
+    setTimeout(() => {
+      const isFocusInMain = this.mainRef.contains(document.activeElement);
+      const isFocusOnLink =
+        document.activeElement && document.activeElement.nodeName === "A";
+      if (isFocusInMain === false && isFocusOnLink === false) {
+        this.mainRef.focus();
+      }
+    }, 0);
+  };
+
   componentDidMount() {
+    document.addEventListener("keydown", this.handleDocumentKeydown);
     if (this.props.file != null) {
       this.getEntriesFromDroppedFile();
     } else if (this.props.cartridge != null) {
@@ -392,8 +407,10 @@ export default class CommonCartridge extends Component {
                   <GridCol width={showcaseSingleResource !== null ? 12 : 10}>
                     <View
                       as="main"
+                      elementRef={ref => (this.mainRef = ref)}
                       margin={this.props.compact ? "none" : "small"}
                       background="default"
+                      tabIndex="-1"
                     >
                       <Switch>
                         <Route

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -310,7 +310,7 @@ export default class Resource extends Component {
       this.props.location.state.from === MODULE_LIST;
     return (
       <React.Fragment>
-        <div>
+        {navigationButtonsEnabled && (previousItem || nextItem) && (
           <Flex margin="0 0 medium">
             <FlexItem padding="small" width="14rem">
               {navigationButtonsEnabled &&
@@ -327,12 +327,9 @@ export default class Resource extends Component {
               </Flex>
             </FlexItem>
           </Flex>
-        </div>
-        <div
-          style={{
-            clear: "both"
-          }}
-        >
+        )}
+
+        <div style={{ clear: "both" }}>
           {isValidExternalToolResource ? (
             <PreviewUnavailable />
           ) : (


### PR DESCRIPTION
Fixes CM-657

Also:

- Don't show empty button container when both prev/next buttons hidden
- Fix console warning