### PR TITLE
Adds support for canvas custom assessment question types

### DIFF
--- a/public/test-cartridges/all-question-types/non_cc_assessments/iaa8f9f400b29e514ea8d28fd7ed067f4.xml.qti
+++ b/public/test-cartridges/all-question-types/non_cc_assessments/iaa8f9f400b29e514ea8d28fd7ed067f4.xml.qti
@@ -723,6 +723,45 @@
         </item>
       </section>
       <item ident="icc924a4c2d9523e1e6e16665819de377" title="Tell me what you think">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>essay_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>1.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>i5ccb43157aa894608ffdeb23aace604a</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;div&gt;
+&lt;p&gt;Write an Essay. Any Essay&lt;/p&gt;
+&lt;p&gt;&lt;img src="https://lorprod.instructure.com/users/2/files/1018/preview?verifier=iSyXwZyPP4yMa5717i8ZqrwgPCK7AfrGXJtRZtIW" alt="profile.jpg" width="128" height="128"&gt;&lt;/p&gt;
+&lt;/div&gt;</mattext>
+          </material>
+          <response_str ident="response1" rcardinality="Single">
+            <render_fib>
+              <response_label ident="answer1" rshuffle="No"/>
+            </render_fib>
+          </response_str>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <other/>
+            </conditionvar>
+          </respcondition>
+        </resprocessing>
       </item>
       <item ident="i784d755a96e4e8c53f76c6252c48f0d2" title="JUST TEXT">
         <itemmetadata>

--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -46,27 +46,37 @@ export default class Assessment extends Component {
       // Select all of the conditions var that the respcondition is empty
       // or has a continue attribute === "No"
 
-      Array.from(
-        itemNode.querySelectorAll('resprocessing respcondition')
-      ).filter(respcondition =>
-        !respcondition.getAttribute("continue")
-        || respcondition.getAttribute("continue") === "No"
-      ).map(rescondition => (conditions = conditions.concat(
-          Array.from(rescondition.querySelectorAll("conditionvar > *"))
-        ))
-      );
+      Array.from(itemNode.querySelectorAll("resprocessing respcondition"))
+        .filter(
+          respcondition =>
+            !respcondition.getAttribute("continue") ||
+            respcondition.getAttribute("continue") === "No"
+        )
+        .map(
+          rescondition =>
+            (conditions = conditions.concat(
+              Array.from(rescondition.querySelectorAll("conditionvar > *"))
+            ))
+        );
 
-      conditions.map(condition => {
+      conditions.forEach(condition => {
         switch (condition.tagName) {
           case "and":
             condition
               .querySelectorAll(":scope > varresult, :scope > varequal")
-              .forEach(result => (responses[result.textContent] = result.getAttribute("respident")));
+              .forEach(
+                result =>
+                  (responses[result.textContent] = result.getAttribute(
+                    "respident"
+                  ))
+              );
             break;
           case "other":
             break;
           default:
-            responses[condition.textContent] = condition.getAttribute("respident")
+            responses[condition.textContent] = condition.getAttribute(
+              "respident"
+            );
             break;
         }
       });
@@ -77,13 +87,17 @@ export default class Assessment extends Component {
         let response_lid_id = response_lid.getAttribute("ident");
         return {
           id: response_lid_id,
-          name: response_lid.querySelector('mattext').textContent,
-          responses: Array.from(response_lid.querySelectorAll("response_label")).map(response => {
+          name: response_lid.querySelector("mattext").textContent,
+          responses: Array.from(
+            response_lid.querySelectorAll("response_label")
+          ).map(response => {
             let response_id = response.getAttribute("ident");
             return {
               id: response_id,
               text: response.querySelector("mattext").textContent,
-              valid: response_id in responses && responses[response_id] === response_lid_id
+              valid:
+                response_id in responses &&
+                responses[response_id] === response_lid_id
             };
           })
         };
@@ -100,7 +114,8 @@ export default class Assessment extends Component {
     const showQuizzesAnswers = !window.location.href.includes("hide-responses");
 
     const questionComponents = items.map((item, index) => {
-      const type = item.metadata.get("question_type") || item.metadata.get("cc_profile");
+      const type =
+        item.metadata.get("question_type") || item.metadata.get("cc_profile");
       const material = item.mattextNode && item.mattextNode.textContent;
 
       return (
@@ -165,25 +180,28 @@ export default class Assessment extends Component {
                   <GridCol width={item.options.length > 1 ? 8 : 5}>
                     <Grid vAlign="middle" margin="none" colSpacing="none">
                       <GridRow>
-                      {item.options &&
-                        item.options.map(optionGroup => 
-                        <GridCol key={optionGroup.id}>
-                          {item.options.length > 1
-                            && <Text lineHeight="double" weight="bold">{optionGroup.name}</Text>}
-                          <Grid vAlign="middle" colSpacing="none">
-                            {optionGroup.responses.map(
-                              option => <GridRow rowSpacing="none" key={option.id}>
-                                <GridCol width={1}>
-                                  {option.valid && (
-                                    <IconCheckMark color="success" />
-                                  )}
-                                </GridCol>
-                                <GridCol>{option.text}</GridCol>
-                              </GridRow>
-                            )}
-                          </Grid>
-                        </GridCol>
-                      )}
+                        {item.options &&
+                          item.options.map(optionGroup => (
+                            <GridCol key={optionGroup.id}>
+                              {item.options.length > 1 && (
+                                <Text lineHeight="double" weight="bold">
+                                  {optionGroup.name}
+                                </Text>
+                              )}
+                              <Grid vAlign="middle" colSpacing="none">
+                                {optionGroup.responses.map(option => (
+                                  <GridRow rowSpacing="none" key={option.id}>
+                                    <GridCol width={1}>
+                                      {option.valid && (
+                                        <IconCheckMark color="success" />
+                                      )}
+                                    </GridCol>
+                                    <GridCol>{option.text}</GridCol>
+                                  </GridRow>
+                                ))}
+                              </Grid>
+                            </GridCol>
+                          ))}
                       </GridRow>
                     </Grid>
                   </GridCol>

--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -40,34 +40,52 @@ export default class Assessment extends Component {
         "presentation > material > mattext"
       );
 
-      let responses = [];
-      const conditions = itemNode.querySelectorAll(
-        'resprocessing respcondition[continue="No"] conditionvar > *'
+      let responses = {};
+      let conditions = [];
+
+      // Select all of the conditions var that the respcondition is empty
+      // or has a continue attribute === "No"
+
+      Array.from(
+        itemNode.querySelectorAll('resprocessing respcondition')
+      ).filter(respcondition =>
+        !respcondition.getAttribute("continue")
+        || respcondition.getAttribute("continue") === "No"
+      ).map(rescondition => (conditions = conditions.concat(
+          Array.from(rescondition.querySelectorAll("conditionvar > *"))
+        ))
       );
 
-      conditions.forEach(condition => {
+      conditions.map(condition => {
         switch (condition.tagName) {
           case "and":
             condition
               .querySelectorAll(":scope > varresult, :scope > varequal")
-              .forEach(result => responses.push(result.textContent));
+              .forEach(result => (responses[result.textContent] = result.getAttribute("respident")));
             break;
           case "other":
             break;
           default:
-            responses.push(condition.textContent);
+            responses[condition.textContent] = condition.getAttribute("respident")
             break;
         }
       });
 
       const options = Array.from(
-        itemNode.querySelectorAll("presentation > response_lid response_label")
-      ).map(response => {
-        let id = response.getAttribute("ident");
+        itemNode.querySelectorAll("presentation > response_lid")
+      ).map(response_lid => {
+        let response_lid_id = response_lid.getAttribute("ident");
         return {
-          id,
-          text: response.querySelector("mattext").textContent,
-          valid: responses.includes(id)
+          id: response_lid_id,
+          name: response_lid.querySelector('mattext').textContent,
+          responses: Array.from(response_lid.querySelectorAll("response_label")).map(response => {
+            let response_id = response.getAttribute("ident");
+            return {
+              id: response_id,
+              text: response.querySelector("mattext").textContent,
+              valid: response_id in responses && responses[response_id] === response_lid_id
+            };
+          })
         };
       });
 
@@ -82,7 +100,7 @@ export default class Assessment extends Component {
     const showQuizzesAnswers = !window.location.href.includes("hide-responses");
 
     const questionComponents = items.map((item, index) => {
-      const type = item.metadata.get("cc_profile");
+      const type = item.metadata.get("question_type") || item.metadata.get("cc_profile");
       const material = item.mattextNode && item.mattextNode.textContent;
 
       return (
@@ -103,43 +121,71 @@ export default class Assessment extends Component {
             />
           )}
 
-          {type === questionTypes.MULTIPLE_CHOICE && (
+          {questionTypes.MULTIPLE_CHOICE.includes(type) && (
             <Pill margin="0 0 small" text={<Trans>Multiple choice</Trans>} />
           )}
-          {type === questionTypes.MULTIPLE_RESPONSE && (
+          {questionTypes.MULTIPLE_RESPONSE.includes(type) && (
             <Pill margin="0 0 small" text={<Trans>Multiple response</Trans>} />
           )}
-          {type === questionTypes.TRUEFALSE && (
+          {questionTypes.TRUEFALSE.includes(type) && (
             <Pill margin="0 0 small" text={<Trans>True / false</Trans>} />
           )}
-          {type === questionTypes.FILL_IN_THE_BLANK && (
+          {questionTypes.FILL_IN_THE_BLANK.includes(type) && (
             <Pill margin="0 0 small" text={<Trans>Fill in the blank</Trans>} />
           )}
-          {type === questionTypes.PATTERN_MATCH && (
+          {questionTypes.PATTERN_MATCH.includes(type) && (
             <Pill margin="0 0 small" text={<Trans>Pattern match</Trans>} />
           )}
-          {type === questionTypes.ESSAY && (
+          {questionTypes.ESSAY.includes(type) && (
             <Pill margin="0 0 small" text={<Trans>Essay</Trans>} />
+          )}
+          {questionTypes.MULTIPLE_DROPDOWN.includes(type) && (
+            <Pill margin="0 0 small" text={<Trans>Multiple Dropdowns</Trans>} />
+          )}
+          {questionTypes.MATCH_QUESTION.includes(type) && (
+            <Pill margin="0 0 small" text={<Trans>Match Questions</Trans>} />
+          )}
+          {questionTypes.NUMERICAL.includes(type) && (
+            <Pill margin="0 0 small" text={<Trans>Numerical</Trans>} />
+          )}
+          {questionTypes.CALCULATED.includes(type) && (
+            <Pill margin="0 0 small" text={<Trans>Calculated</Trans>} />
+          )}
+          {questionTypes.TEXT_ONLY.includes(type) && (
+            <Pill margin="0 0 small" text={<Trans>Text only</Trans>} />
+          )}
+          {questionTypes.FILE_UPLOAD.includes(type) && (
+            <Pill margin="0 0 small" text={<Trans>File Upload</Trans>} />
           )}
 
           {showQuizzesAnswers && (
             <div className="question-answers">
               <Grid vAlign="middle" colSpacing="none">
                 <GridRow>
-                  <GridCol width={5}>
-                    {item.options &&
-                      item.options.map(option => (
-                        <Grid vAlign="middle" colSpacing="none">
-                          <GridRow>
-                            <GridCol width={1}>
-                              {option.valid && (
-                                <IconCheckMark color="success" />
-                              )}
-                            </GridCol>
-                            <GridCol>{option.text}</GridCol>
-                          </GridRow>
-                        </Grid>
-                      ))}
+                  <GridCol width={item.options.length > 1 ? 8 : 5}>
+                    <Grid vAlign="middle" margin="none" colSpacing="none">
+                      <GridRow>
+                      {item.options &&
+                        item.options.map(optionGroup => 
+                        <GridCol key={optionGroup.id}>
+                          {item.options.length > 1
+                            && <Text lineHeight="double" weight="bold">{optionGroup.name}</Text>}
+                          <Grid vAlign="middle" colSpacing="none">
+                            {optionGroup.responses.map(
+                              option => <GridRow rowSpacing="none" key={option.id}>
+                                <GridCol width={1}>
+                                  {option.valid && (
+                                    <IconCheckMark color="success" />
+                                  )}
+                                </GridCol>
+                                <GridCol>{option.text}</GridCol>
+                              </GridRow>
+                            )}
+                          </Grid>
+                        </GridCol>
+                      )}
+                      </GridRow>
+                    </Grid>
                   </GridCol>
                 </GridRow>
               </Grid>

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -93,7 +93,7 @@ export default class ModulesList extends Component {
             }
           }
 
-          if (item.type === resourceTypes.ASSESSMENT_CONTENT ||  item.type === resourceTypes.CANVAS_ASSESTMENT_CONTENT) {
+          if (item.type === resourceTypes.ASSESSMENT_CONTENT) {
             return (
               <AssessmentListItem
                 dependencyHrefs={item.dependencyHrefs}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -93,7 +93,7 @@ export default class ModulesList extends Component {
             }
           }
 
-          if (item.type === resourceTypes.ASSESSMENT_CONTENT) {
+          if (item.type === resourceTypes.ASSESSMENT_CONTENT ||  item.type === resourceTypes.CANVAS_ASSESTMENT_CONTENT) {
             return (
               <AssessmentListItem
                 dependencyHrefs={item.dependencyHrefs}

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -165,6 +165,22 @@ export default class Resource extends Component {
           type="text/xml"
         />
       ),
+      [resourceTypes.CANVAS_ASSESTMENT_CONTENT]: (
+        <EntryDocument
+          getTextByPath={this.props.getTextByPath}
+          href={href}
+          render={doc => (
+            <Assessment
+              getTextByPath={this.props.getTextByPath}
+              getUrlForPath={this.props.getUrlForPath}
+              doc={doc}
+              resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
+            />
+          )}
+          src={this.props.src}
+          type="text/xml"
+        />
+      ),
       [resourceTypes.ASSIGNMENT]: (
         <EntryDocument
           getTextByPath={this.props.getTextByPath}

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -165,22 +165,6 @@ export default class Resource extends Component {
           type="text/xml"
         />
       ),
-      [resourceTypes.CANVAS_ASSESTMENT_CONTENT]: (
-        <EntryDocument
-          getTextByPath={this.props.getTextByPath}
-          href={href}
-          render={doc => (
-            <Assessment
-              getTextByPath={this.props.getTextByPath}
-              getUrlForPath={this.props.getUrlForPath}
-              doc={doc}
-              resourceIdsByHrefMap={this.props.resourceIdsByHrefMap}
-            />
-          )}
-          src={this.props.src}
-          type="text/xml"
-        />
-      ),
       [resourceTypes.ASSIGNMENT]: (
         <EntryDocument
           getTextByPath={this.props.getTextByPath}

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const resourceTypes = {
   ASSOCIATED_CONTENT:
     "associatedcontent/imscc_xmlv1p1/learning-application-resource",
   BLTI: "imsbasiclti_xmlv1p0",
+  CANVAS_ASSESTMENT_CONTENT: 'associatedcontent/imscc_xmlv1p1/learning-application-resource',
   DISCUSSION_TOPIC: "imsdt_xmlv1p1",
   EXTERNAL_TOOL: "external_tool",
   QUESTION_BANK: "imsqti_xmlv1p2/imscc_xmlv1p1/question-bank",
@@ -20,13 +21,21 @@ export const resourceTypes = {
   WEB_LINK: "imswl_xmlv1p1"
 };
 
+
 export const questionTypes = {
-  ESSAY: "cc.essay.v0p1",
-  FILL_IN_THE_BLANK: "cc.fib.v0p1",
-  MULTIPLE_CHOICE: "cc.multiple_choice.v0p1",
-  MULTIPLE_RESPONSE: "cc.multiple_response.v0p1",
-  PATTERN_MATCH: "cc.pattern_match.v0p1",
-  TRUEFALSE: "cc.true_false.v0p1"
+  ESSAY: ["essay_question", "cc.essay.v0p1"],
+  FILL_IN_THE_BLANK: ["cc.fib.v0p1"],
+  MULTIPLE_CHOICE: ["multiple_choice_question", "cc.multiple_choice.v0p1"],
+  MULTIPLE_RESPONSE: ["multiple_answers_question", "cc.multiple_response.v0p1"],
+  PATTERN_MATCH: ["cc.pattern_match.v0p1"],
+  TRUEFALSE: ["true_false_question", "cc.true_false.v0p1"],
+  // Canvas specific types:
+  MULTIPLE_DROPDOWN: ["multiple_dropdowns_question"],
+  MATCH_QUESTION: ["matching_question"],
+  NUMERICAL: ["numerical_question"],
+  CALCULATED: ["calculated_question"],
+  TEXT_ONLY: ["text_only_question"],
+  FILE_UPLOAD: ["file_upload_question"]
 };
 
 export const submissionTypes = {

--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/cy/messages.po
+++ b/src/locales/cy/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/da-x-k12/messages.po
+++ b/src/locales/da-x-k12/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/da/messages.po
+++ b/src/locales/da/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr "(unidentified)"
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr "All Items"
+#~ msgid "All Items"
+#~ msgstr "All Items"
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr "Assignments"
 #~ msgid "Assignments ({0})"
 #~ msgstr "Assignments ({0})"
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr "Assignments ({numberOfAssignments})"
 
@@ -91,7 +91,7 @@ msgstr "Discussions"
 #~ msgid "Discussions ( {0})"
 #~ msgstr "Discussions ( {0})"
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr "Discussions ({0})"
 
@@ -119,7 +119,7 @@ msgstr "External Tool Content Can't be Previewed"
 msgid "External link"
 msgstr "External link"
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr "Failed to load resource"
 
@@ -127,7 +127,7 @@ msgstr "Failed to load resource"
 msgid "Files"
 msgstr "Files"
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr "Files ({0})"
 
@@ -148,11 +148,11 @@ msgstr "In order to use this resource in Canvas, the external tool must be insta
 msgid "Loading"
 msgstr "Loading"
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr "Loading Cartridge"
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr "Loading completion"
 
@@ -166,7 +166,7 @@ msgstr "Max attempts"
 msgid "Media viewer"
 msgstr "Media viewer"
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr "Modules ({0})"
 
@@ -178,7 +178,7 @@ msgstr "Multiple choice"
 msgid "Multiple response"
 msgstr "Multiple response"
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr "Next"
 
@@ -194,7 +194,7 @@ msgstr "Next"
 msgid "Page"
 msgstr "Page"
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr "Pages ({0})"
 
@@ -206,7 +206,7 @@ msgstr "Pattern match"
 msgid "Points"
 msgstr "Points"
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr "Previous"
 
@@ -222,9 +222,13 @@ msgstr "Quiz"
 msgid "Quizzes"
 msgstr "Quizzes"
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
-msgstr "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr "Quizzes ({0})"
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
+msgstr "Quizzes ({numberOfAssessment})"
 
 #: src/ResourceUnavailable.js:11
 msgid "Resource Unavailable"
@@ -238,7 +242,7 @@ msgstr "Resource Unavailable"
 msgid "Submitting"
 msgstr "Submitting"
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr "This may take some time depending on the size of the cartridge."
 
@@ -250,12 +254,12 @@ msgstr "This resource is not included in the package."
 msgid "True / false"
 msgstr "True / false"
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr "Untitled"
 
@@ -275,7 +279,7 @@ msgstr "View Common Cartridges in the browser. Requires no server-side processin
 msgid "View source on Github"
 msgstr "View source on Github"
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr "We had a problem loading the Common Cartridge"
 
@@ -283,7 +287,7 @@ msgstr "We had a problem loading the Common Cartridge"
 msgid "Wiki content"
 msgstr "Wiki content"
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr "You are here:"
 
@@ -295,7 +299,7 @@ msgstr "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr "a file upload"
 
@@ -303,21 +307,21 @@ msgstr "a file upload"
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr "{0} Questions"
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr "{0} points"
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr "{0}%"
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr "{0}% loaded"

--- a/src/locales/en_AU/messages.po
+++ b/src/locales/en_AU/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/en_GB/messages.po
+++ b/src/locales/en_GB/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/fr_CA/messages.po
+++ b/src/locales/fr_CA/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/is/messages.po
+++ b/src/locales/is/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/it/messages.po
+++ b/src/locales/it/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/nb-x-k12/messages.po
+++ b/src/locales/nb-x-k12/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/nb/messages.po
+++ b/src/locales/nb/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/nl/messages.po
+++ b/src/locales/nl/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/pl/messages.po
+++ b/src/locales/pl/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/pt_BR/messages.po
+++ b/src/locales/pt_BR/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/sv-x-k12/messages.po
+++ b/src/locales/sv-x-k12/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/sv/messages.po
+++ b/src/locales/sv/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/locales/zh_HK/messages.po
+++ b/src/locales/zh_HK/messages.po
@@ -13,13 +13,13 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:161
+#: src/ModulesList.js:179
 msgid "(unidentified)"
 msgstr ""
 
 #: src/Resource.js:151
-msgid "All Items"
-msgstr ""
+#~ msgid "All Items"
+#~ msgstr ""
 
 #: src/Assessment.js:131
 #~ msgid "Assessment"
@@ -50,7 +50,7 @@ msgstr ""
 #~ msgid "Assignments ({0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:358
+#: src/CommonCartridge.js:355
 msgid "Assignments ({numberOfAssignments})"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 #~ msgid "Discussions ( {0})"
 #~ msgstr ""
 
-#: src/CommonCartridge.js:370
+#: src/CommonCartridge.js:367
 msgid "Discussions ({0})"
 msgstr ""
 
@@ -119,7 +119,7 @@ msgstr ""
 msgid "External link"
 msgstr ""
 
-#: src/CommonCartridge.js:250
+#: src/CommonCartridge.js:245
 msgid "Failed to load resource"
 msgstr ""
 
@@ -127,7 +127,7 @@ msgstr ""
 msgid "Files"
 msgstr ""
 
-#: src/CommonCartridge.js:388
+#: src/CommonCartridge.js:383
 msgid "Files ({0})"
 msgstr ""
 
@@ -148,11 +148,11 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: src/CommonCartridge.js:268
+#: src/CommonCartridge.js:263
 msgid "Loading Cartridge"
 msgstr ""
 
-#: src/CommonCartridge.js:285
+#: src/CommonCartridge.js:280
 msgid "Loading completion"
 msgstr ""
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "Media viewer"
 msgstr ""
 
-#: src/CommonCartridge.js:353
+#: src/CommonCartridge.js:350
 msgid "Modules ({0})"
 msgstr ""
 
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Multiple response"
 msgstr ""
 
-#: src/Resource.js:134
+#: src/Resource.js:129
 msgid "Next"
 msgstr ""
 
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Page"
 msgstr ""
 
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:360
 msgid "Pages ({0})"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Points"
 msgstr ""
 
-#: src/Resource.js:116
+#: src/Resource.js:108
 msgid "Previous"
 msgstr ""
 
@@ -222,8 +222,12 @@ msgstr ""
 msgid "Quizzes"
 msgstr ""
 
-#: src/CommonCartridge.js:379
-msgid "Quizzes ({0})"
+#: src/CommonCartridge.js:374
+#~ msgid "Quizzes ({0})"
+#~ msgstr ""
+
+#: src/CommonCartridge.js:376
+msgid "Quizzes ({numberOfAssessment})"
 msgstr ""
 
 #: src/ResourceUnavailable.js:11
@@ -238,7 +242,7 @@ msgstr ""
 msgid "Submitting"
 msgstr ""
 
-#: src/CommonCartridge.js:276
+#: src/CommonCartridge.js:271
 msgid "This may take some time depending on the size of the cartridge."
 msgstr ""
 
@@ -250,12 +254,12 @@ msgstr ""
 msgid "True / false"
 msgstr ""
 
-#: src/CommonCartridge.js:339
-#: src/ExternalToolListItem.js:20
-#: src/ModulesList.js:160
+#: src/CommonCartridge.js:336
+#: src/ExternalToolListItem.js:26
+#: src/ModulesList.js:178
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:24
-#: src/utils.js:217
+#: src/WebLinkListItem.js:30
+#: src/utils.js:226
 msgid "Untitled"
 msgstr ""
 
@@ -275,7 +279,7 @@ msgstr ""
 msgid "View source on Github"
 msgstr ""
 
-#: src/CommonCartridge.js:252
+#: src/CommonCartridge.js:247
 msgid "We had a problem loading the Common Cartridge"
 msgstr ""
 
@@ -283,7 +287,7 @@ msgstr ""
 msgid "Wiki content"
 msgstr ""
 
-#: src/CommonCartridge.js:337
+#: src/CommonCartridge.js:334
 msgid "You are here:"
 msgstr ""
 
@@ -295,7 +299,7 @@ msgstr ""
 msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
 msgstr ""
 
-#: src/utils.js:318
+#: src/utils.js:329
 msgid "a file upload"
 msgstr ""
 
@@ -303,21 +307,21 @@ msgstr ""
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr ""
 
-#: src/AssessmentListItem.js:73
+#: src/AssessmentListItem.js:79
 msgid "{0} Questions"
 msgstr ""
 
-#: src/AssessmentListItem.js:80
-#: src/AssignmentListItemBody.js:25
-#: src/DiscussionListItem.js:70
-#: src/FileListItem.js:68
+#: src/AssessmentListItem.js:86
+#: src/AssignmentListItemBody.js:31
+#: src/DiscussionListItem.js:76
+#: src/FileListItem.js:74
 msgid "{0} points"
 msgstr ""
 
-#: src/CommonCartridge.js:294
+#: src/CommonCartridge.js:289
 msgid "{0}%"
 msgstr ""
 
-#: src/CommonCartridge.js:288
+#: src/CommonCartridge.js:283
 msgid "{0}% loaded"
 msgstr ""

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,25 +178,34 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     .filter(node => node.querySelector("file"));
 
   const canvasAssessmentResources = resources
-    .filter(node => 
-      node.getAttribute("href")
-      && node.getAttribute("href").includes("assessment_meta")
-      && is(resourceTypes.CANVAS_ASSESTMENT_CONTENT)
+    .filter(
+      node =>
+        node.getAttribute("href") &&
+        node.getAttribute("href").includes("assessment_meta") &&
+        is(resourceTypes.CANVAS_ASSESTMENT_CONTENT)
     )
     .filter(node => node.querySelector("file"));
 
-  if(canvasAssessmentResources.length > 0) {
+  if (canvasAssessmentResources.length > 0) {
     // Since we have custom canvas assessments, replace the corresponding
     // assesment file with the canvas one so we display all of the content
     // (questions) available instead of only the IMSCC supported ones.
-    assessmentResources.map(resource => {
-      const [identifier] = resource.querySelector("file").getAttribute("href").split("/")
-      const canvasFile = canvasAssessmentResources.map(resource => 
-        resource.querySelector('file[href*="non_cc_assessment"]')  
-      ).filter(file => file.getAttribute('href').includes(identifier))
-      
-      canvasFile && resource.querySelector("file").setAttribute("href", canvasFile[0].getAttribute("href"))
-    })
+    assessmentResources.forEach(resource => {
+      const [identifier] = resource
+        .querySelector("file")
+        .getAttribute("href")
+        .split("/");
+      const canvasFile = canvasAssessmentResources
+        .map(resource =>
+          resource.querySelector('file[href*="non_cc_assessment"]')
+        )
+        .filter(file => file.getAttribute("href").includes(identifier));
+
+      canvasFile &&
+        resource
+          .querySelector("file")
+          .setAttribute("href", canvasFile[0].getAttribute("href"));
+    });
   }
 
   const assignmentResources = resources

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,6 +134,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
     .filter(isNot(resourceTypes.ASSIGNMENT))
     .filter(isNot(resourceTypes.ASSOCIATED_CONTENT))
     .filter(isNot(resourceTypes.ASSESSMENT_CONTENT))
+    .filter(isNot(resourceTypes.CANVAS_ASSESTMENT_CONTENT))
     .filter(isNot(resourceTypes.WEB_CONTENT));
   const discussionResources = resources
     .filter(is(resourceTypes.DISCUSSION_TOPIC))
@@ -175,6 +176,29 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
   const assessmentResources = resources
     .filter(is(resourceTypes.ASSESSMENT_CONTENT))
     .filter(node => node.querySelector("file"));
+
+  const canvasAssessmentResources = resources
+    .filter(node => 
+      node.getAttribute("href")
+      && node.getAttribute("href").includes("assessment_meta")
+      && is(resourceTypes.CANVAS_ASSESTMENT_CONTENT)
+    )
+    .filter(node => node.querySelector("file"));
+
+  if(canvasAssessmentResources.length > 0) {
+    // Since we have custom canvas assessments, replace the corresponding
+    // assesment file with the canvas one so we display all of the content
+    // (questions) available instead of only the IMSCC supported ones.
+    assessmentResources.map(resource => {
+      const [identifier] = resource.querySelector("file").getAttribute("href").split("/")
+      const canvasFile = canvasAssessmentResources.map(resource => 
+        resource.querySelector('file[href*="non_cc_assessment"]')  
+      ).filter(file => file.getAttribute('href').includes(identifier))
+      
+      canvasFile && resource.querySelector("file").setAttribute("href", canvasFile[0].getAttribute("href"))
+    })
+  }
+
   const assignmentResources = resources
     .filter(is(resourceTypes.ASSIGNMENT))
     .filter(node => node.querySelector("file"));

--- a/tests/test.quizzes-types.js
+++ b/tests/test.quizzes-types.js
@@ -23,7 +23,7 @@ test("Quizzes types are shown", async t => {
     .ok()
     .expect(questions.withText("MATCH QUESTIONS").exists)
     .ok()
-    .expect(questions.withText("NUMUERICAL").exists)
+    .expect(questions.withText("NUMERICAL").exists)
     .ok()
     .expect(questions.withText("CALCULATED").exists)
     .ok()

--- a/tests/test.quizzes-types.js
+++ b/tests/test.quizzes-types.js
@@ -38,17 +38,17 @@ test("Quiz correct answer is shown", async t => {
 });
 
 test("when hide-responses flag is set in the url, quizzes responses are hidden", async t => {
-  const assesstmentQuestions = Selector(".question-answers");
+  const assessmentQuestions = Selector(".question-answers");
   await t.navigateTo(
     `http://localhost:5000/?manifest=${encodeURIComponent(
       "/test-cartridges/all-question-types/imsmanifest.xml"
     )}#/`
   );
-  await t.expect(assesstmentQuestions.exists);
+  await t.expect(assessmentQuestions.exists);
   await t.navigateTo(
     `http://localhost:5000/?hide-responses&manifest=${encodeURIComponent(
       "/test-cartridges/all-question-types/imsmanifest.xml"
     )}#/`
   );
-  await t.expect(assesstmentQuestions.exists).notOk();
+  await t.expect(assessmentQuestions.exists).notOk();
 });

--- a/tests/test.quizzes-types.js
+++ b/tests/test.quizzes-types.js
@@ -18,6 +18,18 @@ test("Quizzes types are shown", async t => {
     .expect(questions.withText("MULTIPLE RESPONSE").exists)
     .ok()
     .expect(questions.withText("ESSAY").exists)
+    .ok()
+    expect(questions.withText("MULTIPLE DROPDOWNS").exists)
+    .ok()
+    expect(questions.withText("MATCH QUESTIONS").exists)
+    .ok()
+    expect(questions.withText("NUMUERICAL").exists)
+    .ok()
+    expect(questions.withText("CALCULATED").exists)
+    .ok()
+    expect(questions.withText("TEXT ONLY").exists)
+    .ok()
+    expect(questions.withText("FILE UPLOAD").exists)
     .ok();
 });
 

--- a/tests/test.quizzes-types.js
+++ b/tests/test.quizzes-types.js
@@ -19,17 +19,17 @@ test("Quizzes types are shown", async t => {
     .ok()
     .expect(questions.withText("ESSAY").exists)
     .ok()
-    expect(questions.withText("MULTIPLE DROPDOWNS").exists)
+    .expect(questions.withText("MULTIPLE DROPDOWNS").exists)
     .ok()
-    expect(questions.withText("MATCH QUESTIONS").exists)
+    .expect(questions.withText("MATCH QUESTIONS").exists)
     .ok()
-    expect(questions.withText("NUMUERICAL").exists)
+    .expect(questions.withText("NUMUERICAL").exists)
     .ok()
-    expect(questions.withText("CALCULATED").exists)
+    .expect(questions.withText("CALCULATED").exists)
     .ok()
-    expect(questions.withText("TEXT ONLY").exists)
+    .expect(questions.withText("TEXT ONLY").exists)
     .ok()
-    expect(questions.withText("FILE UPLOAD").exists)
+    .expect(questions.withText("FILE UPLOAD").exists)
     .ok();
 });
 


### PR DESCRIPTION
This PR adds support to the custom file canvas adds to the cartridge. Note that in order to do that, only the file href attribute is changed at the resource level, after that I had to implement new logic in order to support the canvas specific question types.