### PR TITLE
Fix: handle resource xml fetch failure

### DIFF
--- a/src/AssessmentListItem.js
+++ b/src/AssessmentListItem.js
@@ -20,6 +20,17 @@ export default class AssessmentListItem extends Component {
     const parser = new DOMParser();
     const path = this.props.href.substr(1);
     const xml = await this.props.getTextByPath(path);
+    if (xml === null) {
+      this.setState({
+        isLoading: false,
+        title: "Error: Resource Not Found",
+        points: "N/A",
+        questionCount: 0,
+        workflowState: "unpublished",
+        resourceNotFound: true
+      });
+      return;
+    }
     const doc = parser.parseFromString(xml, "text/xml");
     const depPath = this.props.dependencyHrefs[0];
     const depXml = await this.props.getTextByPath(depPath);
@@ -55,6 +66,10 @@ export default class AssessmentListItem extends Component {
       ? "success"
       : "secondary";
 
+    const pathname = this.state.resourceNotFound
+      ? `resources/unavailable`
+      : `resources/${this.props.identifier}`;
+
     return (
       <li className="ExpandCollapseList-item">
         <div className="ExpandCollapseList-item-inner">
@@ -66,7 +81,7 @@ export default class AssessmentListItem extends Component {
               <Link
                 as={RouterLink}
                 to={{
-                  pathname: `resources/${this.props.identifier}`,
+                  pathname,
                   state: { from: this.props.from }
                 }}
               >

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -15,11 +15,20 @@ export default class AssignmentListItem extends Component {
   async componentDidMount() {
     const path = this.props.href.substr(1);
     const xml = await this.props.getTextByPath(path);
+    if (xml === null) {
+      this.setState({
+        isLoading: false,
+        title: "Error: Resource Not Found",
+        points: "N/A",
+        workflowState: "unpublished",
+        resourceNotFound: true
+      });
+      return;
+    }
     const parser = new DOMParser();
     const doc = parser.parseFromString(xml, "text/xml");
     const title =
       doc.querySelector("title") && doc.querySelector("title").textContent;
-    const description = doc.querySelector("text").textContent;
     const gradableNode = doc.querySelector("gradable");
     const points =
       gradableNode &&
@@ -35,7 +44,6 @@ export default class AssignmentListItem extends Component {
     this.setState({
       isLoading: false,
       title,
-      description,
       points,
       workflowState
     });
@@ -55,10 +63,10 @@ export default class AssignmentListItem extends Component {
         iconColor={iconColor}
         identifier={this.props.identifier}
         title={this.state.title}
-        description={this.state.workflowState}
         points={this.state.points}
         workflowState={this.state.workflowState}
         from={this.props.from}
+        resourceNotFound={this.state.resourceNotFound}
       />
     );
   }

--- a/src/AssignmentListItemBody.js
+++ b/src/AssignmentListItemBody.js
@@ -7,6 +7,9 @@ import WorkflowStateIcon from "./WorkflowStateIcon";
 
 export default class AssignmentListItemBody extends PureComponent {
   render() {
+    const pathname = this.props.resourceNotFound
+      ? `resources/unavailable`
+      : `resources/${this.props.identifier}`;
     return (
       <li className="ExpandCollapseList-item">
         <div className="ExpandCollapseList-item-inner">
@@ -17,7 +20,7 @@ export default class AssignmentListItemBody extends PureComponent {
             <Link
               as={RouterLink}
               to={{
-                pathname: `resources/${this.props.identifier}`,
+                pathname,
                 state: { from: this.props.from }
               }}
             >

--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -18,6 +18,16 @@ export default class AssociatedContentAssignmentListItem extends Component {
     const parser = new DOMParser();
     const path = this.props.href.substr(1);
     const assignmentXml = await this.props.getTextByPath(path);
+    if (assignmentXml === null) {
+      this.setState({
+        isLoading: false,
+        title: "Error: Resource Not Found",
+        pointsPossible: "N/A",
+        workflowState: "unpublished",
+        resourceNotFound: true
+      });
+      return;
+    }
     const doc = parser.parseFromString(assignmentXml, "text/xml");
     const title =
       doc.querySelector("title") &&
@@ -64,6 +74,7 @@ export default class AssociatedContentAssignmentListItem extends Component {
         points={this.state.pointsPossible}
         workflowState={this.state.workflowState}
         from={this.props.from}
+        resourceNotFound={this.state.resourceNotFound}
       />
     );
   }

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -183,7 +183,9 @@ export default class CommonCartridge extends Component {
   getTextByPath = path =>
     this.state.isCartridgeRemotelyExpanded
       ? fetch(`${this.state.basepath}/${path}`)
-          .then(response => response.text())
+          .then(response => {
+            return response.ok ? response.text() : null;
+          })
           .catch(err => null)
       : this.state.entryMap.has(path)
       ? getTextFromEntry(this.state.entryMap.get(path))

--- a/src/DiscussionListItem.js
+++ b/src/DiscussionListItem.js
@@ -18,6 +18,16 @@ export default class DiscussionListItem extends Component {
   async componentDidMount() {
     const path = this.props.href.substr(1);
     const xml = await this.props.getTextByPath(path);
+    if (xml === null) {
+      this.setState({
+        isLoading: false,
+        title: "Error: Resource Not Found",
+        points: "N/A",
+        workflowState: "unpublished",
+        resourceNotFound: true
+      });
+      return;
+    }
     const parser = new DOMParser();
     const doc = parser.parseFromString(xml, "text/xml");
     const title = doc.querySelector("title").textContent;
@@ -51,6 +61,10 @@ export default class DiscussionListItem extends Component {
       ? "success"
       : "secondary";
 
+    const pathname = this.state.resourceNotFound
+      ? `resources/unavailable`
+      : `resources/${this.props.identifier}`;
+
     return (
       <li className="ExpandCollapseList-item">
         <div className="ExpandCollapseList-item-inner">
@@ -62,7 +76,7 @@ export default class DiscussionListItem extends Component {
             <Link
               as={RouterLink}
               to={{
-                pathname: `resources/${this.props.identifier}`,
+                pathname,
                 state: { from: this.props.from }
               }}
             >

--- a/src/WikiContentListItem.js
+++ b/src/WikiContentListItem.js
@@ -23,6 +23,15 @@ export default class WikiContentListItem extends Component {
   async componentDidMount() {
     const path = this.props.href.substr(1);
     const xml = await this.props.getTextByPath(path);
+    if (xml === null) {
+      this.setState({
+        isLoading: false,
+        title: "Error: Resource Not Found",
+        workflowState: "unpublished",
+        resourceNotFound: true
+      });
+      return;
+    }
     const parser = new DOMParser();
     const doc = parser.parseFromString(xml, "text/html");
     const itemTitle = this.props.item != null && this.props.item.title;
@@ -51,6 +60,10 @@ export default class WikiContentListItem extends Component {
       ? "success"
       : "secondary";
 
+    const pathname = this.state.resourceNotFound
+      ? `resources/unavailable`
+      : `resources/${this.props.identifier}`;
+
     return (
       <li className="ExpandCollapseList-item">
         <div className="ExpandCollapseList-item-inner">
@@ -61,7 +74,7 @@ export default class WikiContentListItem extends Component {
             <Link
               as={RouterLink}
               to={{
-                pathname: `resources/${this.props.identifier}`,
+                pathname,
                 state: { from: this.props.from }
               }}
             >


### PR DESCRIPTION
Note:
- I couldn't write a test for this because `superstatic` won't give you a 404 when you try to access a static file that doesn't exist - it just redirects you to `/`