### PR TITLE
Fix: handle no showable resources

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -271,16 +271,12 @@ export default class CommonCartridge extends Component {
       );
     }
 
-    let showcaseSingleResource = null;
-    if (result.resources.length === 1) {
-      showcaseSingleResource = result.resources[0];
-    } else if (
+    const showcaseSingleResource =
       this.props.compact &&
       result.modules.length === 0 &&
       result.showcaseResources.length === 1
-    ) {
-      showcaseSingleResource = this.state.showcaseResources[0];
-    }
+        ? this.state.showcaseResources[0]
+        : null;
 
     this.setState({
       ...result,


### PR DESCRIPTION
Fixes issue where previewing a course that has module links, but no showable resources was crashing the app.

Test Plan:
- Obtain an imscc that has module links, but doesn't include showable content (due to external tools, missing resources, etc.)
- Preview the imscc
- The module list is rendered and list items take you to an error page.