### PR TITLE
Allow DocViewer previews to be fullscreen

### DIFF
--- a/src/EmbeddedPreview.js
+++ b/src/EmbeddedPreview.js
@@ -89,6 +89,7 @@ export default class EmbeddedPreview extends Component {
                 <iframe
                   title={i18n._(t`Media viewer`)}
                   src={this.state.embeddedViewerSrc}
+                  allowfullscreen
                 />
               )
             }


### PR DESCRIPTION
Refs CM-646

The iframe we're launching DocViewer in needs to have fullscreen
enabled