### PR TITLE
Fix: Hide left nav for single-resource cartridges

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -272,9 +272,9 @@ export default class CommonCartridge extends Component {
     }
 
     const showcaseSingleResource =
-      this.props.compact &&
       result.modules.length === 0 &&
-      result.showcaseResources.length === 1
+      result.showcaseResources.length === 1 &&
+      result.fileResources.length === 0
         ? this.state.showcaseResources[0]
         : null;
 

--- a/tests/test.quizzes-types.js
+++ b/tests/test.quizzes-types.js
@@ -5,7 +5,6 @@ fixture`Quiz with all question types`
 
 test("Resource loads as quiz", async t => {
   await t.expect(Selector(".resource-label").withText("QUIZ").exists).ok();
-  await t.expect(Selector(".MenuItem").withText("Quizzes (1)").exists).ok();
 });
 
 test("Quizzes types are shown", async t => {

--- a/tests/test.single-assignment.js
+++ b/tests/test.single-assignment.js
@@ -1,18 +1,20 @@
 import { Selector } from "testcafe";
 
-fixture`Single assignment cartridge (with attachment)`
+fixture`Single assignment cartridge`
   .page`http://localhost:5000/?manifest=${encodeURIComponent(
   "/test-cartridges/single-assignment/imsmanifest.xml"
 )}`;
 
-test("Header, Nav and assignment is displayed", async t => {
+test("Header and assignment is displayed", async t => {
   await t
     .expect(Selector("h1").withText(`Assignment`).exists)
     .ok()
-    .expect(Selector("nav").exists)
-    .ok()
     .expect(Selector("header").exists)
     .ok();
+});
+
+test("Nav is hidden", async t => {
+  await t.expect(Selector("nav").exists).notOk();
 });
 
 fixture`Single assignment cartridge (with attachment, compact)`

--- a/tests/test.single-discussion-with-attachment.js
+++ b/tests/test.single-discussion-with-attachment.js
@@ -13,7 +13,8 @@ test("Header, Content, Nav, and Files are displayed", async t => {
     .ok()
     .expect(Selector("header").exists)
     .ok()
-    .expect(Selector("a.MenuItem").withText("Files (1)").exists);
+    .expect(Selector("a.MenuItem").withText("Files (1)").exists)
+    .ok();
 });
 
 test("Discussion attachment links are displayed", async t => {
@@ -31,12 +32,10 @@ fixture`Single discussion cartridge (with attachment, compact)`
   "/test-cartridges/single-discussion/imsmanifest.xml"
 )}`;
 
-test("Header and Nav is hidden", async t => {
+test("Header is hidden", async t => {
   await t
     .expect(Selector("h1").withText(`Test discussion`).exists)
     .ok()
-    .expect(Selector("nav").exists)
-    .notOk()
     .expect(Selector("header").exists)
     .notOk();
 });

--- a/tests/test.single-page-no-attachment.js
+++ b/tests/test.single-page-no-attachment.js
@@ -5,11 +5,9 @@ fixture`Single page cartridge`
   "/test-cartridges/single-page/imsmanifest.xml"
 )}`;
 
-test("Header and Nav is displayed", async t => {
+test("Header and assignment is displayed", async t => {
   await t
     .expect(Selector("h1").withText(`Our Purpose`).exists)
-    .ok()
-    .expect(Selector("nav").exists)
     .ok()
     .expect(Selector("header").exists)
     .ok();
@@ -28,8 +26,8 @@ test("Header and Nav is hidden", async t => {
   await t
     .expect(Selector("h1").withText(`Our Purpose`).exists)
     .ok()
-    .expect(Selector("nav").exists)
-    .notOk()
     .expect(Selector("header").exists)
+    .notOk()
+    .expect(Selector("nav").exists)
     .notOk();
 });


### PR DESCRIPTION
Fixes #119 

Test Plan:
- Preview a cartridge that only contains a single resource
- Do not supply the `compact` query param
- The resource is shown but the nav menu is not

[Example](https://deploy-preview-126--common-cartridge-viewer.netlify.com/?manifest=/test-cartridges/single-discussion/imsmanifest.xml#/)