### PR TITLE
Fix: render matching questions vertically

### DIFF
--- a/src/Assessment.js
+++ b/src/Assessment.js
@@ -179,7 +179,7 @@ export default class Assessment extends Component {
                 <GridRow>
                   <GridCol width={item.options.length > 1 ? 8 : 5}>
                     <Grid vAlign="middle" margin="none" colSpacing="none">
-                      <GridRow>
+                      <GridRow startAt={null}>
                         {item.options &&
                           item.options.map(optionGroup => (
                             <GridCol key={optionGroup.id}>
@@ -191,10 +191,16 @@ export default class Assessment extends Component {
                               <Grid vAlign="middle" colSpacing="none">
                                 {optionGroup.responses.map(option => (
                                   <GridRow rowSpacing="none" key={option.id}>
-                                    <GridCol width={1}>
-                                      {option.valid && (
-                                        <IconCheckMark color="success" />
-                                      )}
+                                    <GridCol width="auto">
+                                      <IconCheckMark
+                                        color="success"
+                                        className="Assessment--IconCheckMark"
+                                        style={{
+                                          visibility: option.valid
+                                            ? "visible"
+                                            : "hidden"
+                                        }}
+                                      />
                                     </GridCol>
                                     <GridCol>
                                       <RichContent

--- a/src/index.css
+++ b/src/index.css
@@ -197,3 +197,7 @@ h3 {
 .EmbeddedPreview--audio {
   max-width: 100%;
 }
+
+.Assessment--IconCheckMark {
+  min-width: 32px;
+}


### PR DESCRIPTION
Fixes CM-698

Before: https://monosnap.com/file/8ArFwPyqPbZMb2YXkp9XvTQqPTigsl
After: https://monosnap.com/file/cjLMtmRaR06HScm65ODjsFPAcLdibU

Test Plan:
- Preview a quiz that contains matching questions.
- The matching questions are stacked, not horizontal.