### PR TITLE
Add Translations

### DIFF
--- a/src/locales/ar/messages.po
+++ b/src/locales/ar/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:30-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(غير معرّف)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "جميع العناصر"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "التقييم"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "التقييمات"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "التقييمات ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "لتقييمات ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "المهمة"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "المهام"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "المهام ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "المهام ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "المرفقات"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "كارتريدج"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "انقر هنا لفتح ارتباط في نافذة جديدة"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "النقاش"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "النقاشات"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "النقاشات ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "لنقاشات ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "اسحب وأفلت أو انقر لاستعراض الكمبيوتر الخاص بك"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "مقال"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "الأمثلة"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "يتعذر معاينة محتوى الأداة الخارجية"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "الارتباط الخارجي"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "الملفات"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "الملفات ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "تعبئة الفراغ"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "صورة"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "من أجل استخدام هذا المورد في Canvas، يجب تثبيت الأداة الخارجية."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "جارٍ التحميل"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "جارٍ تحميل الكارتريدج"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "إكمال التحميل"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "الوحدات النمطية ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "اختيار من متعدد"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "استجابة من متعدد"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "التالي"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "لم يتم العثور عليه"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "نوع آخر"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "صفحة"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "الصفحات ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "مطابقة النمط"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "نقاط"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "السابق"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "الأسئلة"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,72 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "جارٍ الإرسال"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "قد يستغرق هذا بعض الوقت حسب حجم الكارتريدج."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "صواب / خطأ"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "بدون عنوان"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "عرض"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "عرض Common Cartridges في المستعرض.\n"
+"لا تتطلب معالجة جانب الخادم."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "عرض Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "عرض المصدر على Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "محتوى ويكي"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "أنت هنا:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "تحميل ملف"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (تمكين مشاركة الموارد عبر المصادر)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} من الأسئلة"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} من النقاط"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "تم تحميل {0}%"

--- a/src/locales/cy/messages.po
+++ b/src/locales/cy/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:30-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(anhysbys)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Pob Eitem"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Asesiad"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Asesiadau"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Asesiadau ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Asesiadau ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Aseiniad"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Aseiniadau"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Aseiniadau ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Aseiniadau ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Atodiadau"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cetrisen"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Cliciwch yma i agor dolen mewn tudalen newydd"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Trafodaeth"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Trafodaethau"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Trafodaethau ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Trafodaethau ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Gallwch lusgo a gollwng, neu glicio i bori drwy’ch cyfrifiadur"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Traethawd"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Enghreifftiau"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Does dim modd gweld rhagolwg o gynnwys adnodd allanol"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Dolen allanol"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Ffeiliau"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Ffeiliau ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Llenwi'r bwlch"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Delwedd"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Er mwyn defnyddio’r adnodd hwn yn Canvas, rhaid i’r adnodd allanol fod wedi’i osod."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Wrthi’n llwytho"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Wrthi’n llwytho cetrisen"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Cwblhau llwytho"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Modiwlau ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Mwy nag un dewis"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Mwy nag un ymateb"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Nesaf"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Heb ei ganfod"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Math arall"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Tudalen"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Tudalennau ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Patrwm yn cyfateb"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Pwynt"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Blaenorol"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Cwestiwn"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Wrthi'n Cyflwyno"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Fe allai hyn gymryd peth amser, gan ddibynnu ar faint y Cetrisen."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Gwir / ffug"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Dideitl"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Gweld"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Gweld Common Cartridge yn y porwr. Does dim angen prosesu ar ochr y gweinydd."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Gweld Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Gweld Ffynhonnell ar Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Cynnwys Wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Rydych chi yma:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "ffeil wedi’i llwytho i fyny"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS wedi’i alluogi)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Cwestiwn"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} pwynt"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% wedi llwytho"

--- a/src/locales/da/messages.po
+++ b/src/locales/da/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:30-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(uidentificeret)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Alle elementer"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Bedømmelse"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Vurderinger"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Vurderinger ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Vurderinger ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Opgave"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Opgaver"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Opgaver ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Opgaver ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Vedhæftede filer"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Klik her for at åbne linket i et nyt vindue"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Diskussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Diskussioner"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Diskussioner ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Diskussioner ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Træk og slip eller klik for at browse din computer"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Opgave"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Eksempler"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Eksternt værktøjsindhold kan ikke forhåndsvises"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Eksternt link"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Filer"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Filer ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Udfyld de tomme felter"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Billede"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "For at kunne bruge denne ressource i Canvas skal det eksterne værktøj installeres."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Indlæser"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Indlæser Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Indlæser færdiggørelse"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Moduler ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Flere valg"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Flere svar"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Næste"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Ikke fundet"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Anden type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Side"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Sider ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Mønster-match"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Point"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Forrige"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Spørgsmål"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Afleverer"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Dette kan tage lidt tid afhængigt af Cartridge-størrelsen."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Sandt / falsk"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Uden titel"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Vis"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Se Common Cartridge i browseren. Kræver ingen behandling på server-siden."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Se en Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Se kilde på Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki-indhold"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Du er her:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "en filoverførsel"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} spørgsmål"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} point"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% indlæst"

--- a/src/locales/de/messages.po
+++ b/src/locales/de/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(Unbekannt)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Alle Elemente"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Bewertung"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Bewertungen"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Bewertungen ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Bewertungen ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Aufgabe"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Aufgaben"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Aufgaben ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Aufgaben ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Anhänge"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Klicken Sie hier, um den Link in neuem Fenster zu öffnen"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Diskussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Diskussionen"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Diskussionen ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Diskussionen ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Ziehen und Ablegen, oder klicken, um Ihren Computer zu durchsuchen"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Essay"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Beispiele:"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Externer Tool-Content bietet keine Vorschau"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Externer Link"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Dateien"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Dateien ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Auslassungen einfügen"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Bild"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Um diese Ressource in Canvas nutzen zu können, muss das externe Tool installiert sein."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Wird geladen"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Cartridge wird geladen"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Laden abschließen"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Module ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Multiple Choice"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Mehrere Antworten"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Weiter"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Nicht gefunden"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Anderer Typ"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Seite"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Seiten ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Musterübereinstimmung"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Punkte"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Vorherige"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Fragen"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Wird eingereicht"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Je nach Größe der Cartridge kann es einige Zeit in Anspruch nehmen."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Wahr oder falsch"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Ohne Titel"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Anzeigen"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Common Cartridges im Browser anzeigen. Keine serverseitige Verarbeitung erforderlich."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Anzeigen einer Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Quelle auf Github anzeigen"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki-Content"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Sie sind hier:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "eine hochgeladene Datei"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS aktiviert)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Fragen"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} Punkte"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0} %"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0} % geladen"

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,25 +13,25 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
 msgstr "(unidentified)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr "All Items"
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "All Items"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr "Assessment"
+msgid "Assessment"
+msgstr "Assessment"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr "Assessments"
+msgid "Assessments"
+msgstr "Assessments"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr "Assessments ( {0})"
+msgid "Assessments ( {0})"
+msgstr "Assessments ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
@@ -50,7 +50,7 @@ msgstr "Assignments"
 #~ msgid "Assignments ({0})"
 #~ msgstr "Assignments ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
 msgstr "Assignments ({numberOfAssignments})"
 
@@ -59,29 +59,13 @@ msgstr "Assignments ({numberOfAssignments})"
 msgid "Attachments"
 msgstr "Attachments"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr "Calculated"
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
 msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
 msgstr "Click here to open link in new window"
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr "Common Cartridge Viewer"
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr "Course Navigation Cannot Be Previewed"
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr "Course navigation links are only available within a Canvas course."
 
 #: src/Discussion.js:40
 msgid "Discussion"
@@ -92,30 +76,26 @@ msgid "Discussions"
 msgstr "Discussions"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr "Discussions ( {0})"
+msgid "Discussions ( {0})"
+msgstr "Discussions ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr "Discussions ({0})"
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr "Drag and drop the cartridge, or click to browse your computer."
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussions ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr "Drag and drop, or click to browse your computer"
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Drag and drop, or click to browse your computer"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
 msgstr "Essay"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
 msgstr "Examples"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
 msgstr "External Tool Content Can't be Previewed"
 
@@ -123,23 +103,15 @@ msgstr "External Tool Content Can't be Previewed"
 msgid "External link"
 msgstr "External link"
 
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr "Failed to load resource"
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr "File Upload"
-
 #: src/FileList.js:38
 msgid "Files"
 msgstr "Files"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
 msgstr "Files ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
 msgstr "Fill in the blank"
 
@@ -147,78 +119,55 @@ msgstr "Fill in the blank"
 msgid "Image"
 msgstr "Image"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
 msgstr "In order to use this resource in Canvas, the external tool must be installed."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
 msgstr "Loading"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
 msgstr "Loading Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
 msgstr "Loading completion"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr "Match Questions"
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr "Max attempts"
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr "Media viewer"
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
 msgstr "Modules ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr "Multiple Dropdowns"
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
 msgstr "Multiple choice"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
 msgstr "Multiple response"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
 msgstr "Next"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr "Not found"
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr "Numerical"
+msgid "Not found"
+msgstr "Not found"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr "Other type"
+msgid "Other type"
+msgstr "Other type"
 
 #: src/WikiContent.js:25
 msgid "Page"
 msgstr "Page"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
 msgstr "Pages ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
 msgstr "Pattern match"
 
@@ -226,33 +175,13 @@ msgstr "Pattern match"
 msgid "Points"
 msgstr "Points"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
 msgstr "Previous"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
 msgstr "Questions"
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr "Quiz"
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr "Quizzes"
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr "Quizzes ({0})"
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr "Quizzes ({numberOfAssessment})"
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr "Resource Unavailable"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -262,98 +191,69 @@ msgstr "Resource Unavailable"
 msgid "Submitting"
 msgstr "Submitting"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr "Text only"
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
 msgstr "This may take some time depending on the size of the cartridge."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr "This resource is not included in the package."
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
 msgstr "True / false"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
 msgstr "Untitled"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
 msgstr "View"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
 msgstr "View Common Cartridges in the browser. Requires no server-side processing."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr "View a Common Cartridge (.imscc)"
+msgid "View a Common Cartridge (.imscc)"
+msgstr "View a Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
 msgstr "View source on Github"
 
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr "We had a problem loading the Common Cartridge"
-
 #: src/WikiContentList.js:60
 msgid "Wiki content"
 msgstr "Wiki content"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
 msgstr "You are here:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
 msgstr "a file upload"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
 msgstr "{0} Questions"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr "{0} is published"
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr "{0} is unpublished"
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
 msgstr "{0} points"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
 msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
 msgstr "{0}% loaded"

--- a/src/locales/en_AU/messages.po
+++ b/src/locales/en_AU/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,347 +13,247 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(unidentified)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "All Items"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Assessment"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Assessments"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Assessments ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Assessments ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Assignment"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Assignments"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Assignments ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Assignments ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Attachments"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Click here to open link in new window"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussions"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussions ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussions ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Drag and drop, or click to browse your computer"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Essay"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Examples"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "External Tool Content Can't be Previewed"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "External link"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Files"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Files ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Fill in the blank"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "In order to use this resource in Canvas, the external tool must be installed."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Loading"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Loading Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Loading completion"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Modules ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Multiple choice"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Multiple response"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Next"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Not found"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Other type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Pages ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Pattern match"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Points"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Previous"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Questions"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
-#~ msgstr ""
+#~ msgstr "Submission formats"
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Submitting"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "This may take some time depending on the size of the cartridge."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "True / false"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Untitled"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "View"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "View Common Cartridges in the browser. Requires no server-side processing."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "View a Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "View source on Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki content"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "You are here:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "a file upload"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Questions"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} points"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% loaded"

--- a/src/locales/en_GB/messages.po
+++ b/src/locales/en_GB/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,347 +13,247 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(unidentified)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "All items"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Assessment"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Assessments"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Assessments ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Assessments ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Assignment"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Assignments"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Assignments ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Assignments ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Attachments"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Click here to open link in new window"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussions"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussions ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussions ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Drag and drop, or click to browse your computer"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Essay"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Examples"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "External Tool Content Can't be Previewed"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "External link"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Files"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Files ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Fill in the blank"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "In order to use this resource in Canvas, the external tool must be installed."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Loading"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Loading Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Loading completion"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Modules ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Multiple choice"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Multiple response"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Next"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Not found"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Other type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Pages ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Pattern match"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Points"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Previous"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Questions"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
-#~ msgstr ""
+#~ msgstr "Submission formats"
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Submitting"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "This may take some time depending on the size of the cartridge."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "True / false"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Untitled"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "View"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "View Common Cartridges in the browser. Requires no server-side processing."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "View a Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "View source on Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki content"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "You are here:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "a file upload"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Questions"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} points"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% loaded"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(no identificado)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Todos los elementos"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Evaluación"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Evaluaciones"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Evaluaciones ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Evaluaciones ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Tarea"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Tareas"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Tareas ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Tareas ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Archivos adjuntos"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartucho"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Haga clic aquí para abrir el enlace en una ventana nueva"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Foro"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Foros"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Foros ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Foros ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Arrastre y suelte, o haga clic para buscar en su computadora"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Ensayo"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Ejemplos"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "El contenido externo de la herramienta no puede verse previamente"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Enlace externo"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Archivos"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Archivos ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Completar el espacio en blanco"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Imagen"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Para utilizar este recurso en Canvas, se debe instalar la herramienta externa."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Cargando"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Cargando el cartucho"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Finalización de la carga"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Módulos ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Opción múltiple"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Respuesta múltiple"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Siguiente"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "No se encontró"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Otro tipo"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Página"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Páginas ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Coincidencia de patrones"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Puntos"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Preguntas"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Presentando"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Esto puede llevar algún tiempo según el tamaño del cartucho."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Verdadero/falso"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Sin título"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Vista"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Ver Common Cartridges en el navegador. No necesita procesamiento del lado del servidor."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Ver Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Ver fuente en Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Contenido wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Usted está aquí:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "una carga de archivo"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (Se permite el Intercambio de recursos de origen cruzado [Cross-Origin Resource Sharing,CORS]"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Preguntas"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} puntos"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% cargado"

--- a/src/locales/fr/messages.po
+++ b/src/locales/fr/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(Non identifié)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Tous les éléments"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Évaluation"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Évaluations"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Évaluations ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Évaluations ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Travaux"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Devoirs"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Devoirs ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Devoirs ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Pièces jointes"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartouche"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Cliquez ici pour ouvrir le lien dans une nouvelle fenêtre"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussions"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussions ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussions ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Glissez et déposez ou cliquez pour rechercher sur votre ordinateur"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Essai"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Exemples"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Le contenu de l’outil externe ne peut pas être prévisualisé"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Lien externe"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Fichiers"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Fichiers ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Remplissez les blancs"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "L’outil externe doit être installé pour pouvoir utiliser cette ressource dans Canvas."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Chargement"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Chargement de la cartouche"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Terminaison du chargement"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Modules ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Choix multiple"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Réponse multiple"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Non trouvé"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Autre type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Pages ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Correspondance de schéma"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Points"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Précédent"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Questions"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Soumission en cours"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Ceci peut prendre un certain temps en fonction de la taille de la cartouche."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Vrai / Faux"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Sans titre"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Afficher"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Afficher les cartouches communes dans le navigateur. Ne nécessite aucun traitement au niveau du serveur."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Afficher une cartouche commune (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Afficher source sur Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Contenu Wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Vous êtes ici :"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "un téléchargement de fichier"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS activé)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} questions"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} points"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% chargement"

--- a/src/locales/fr_CA/messages.po
+++ b/src/locales/fr_CA/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(non identifié)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Tous les éléments"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Évaluation"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Évaluations"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Évaluations ( {0} )"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Évaluations ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Tâche"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Tâches"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Tâches ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Tâches ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Pièces jointes"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartouche"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Cliquez ici pour ouvrir le lien dans une nouvelle fenêtre"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussions"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussions ( {0} )"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussions ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Glisser et déposer ou cliquer pour naviguer sur l’ordinateur"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Composition"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Exemples"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Le contenu de l'outil externe ne peut pas être prévisualisé"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Lien externe"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Fichiers"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Fichiers ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Champ à compléter"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Afin d'utiliser cette ressource dans Canvas, l'outil externe doit être installé."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "En cours de chargement"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Cartouche en cours de chargement"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Achèvement en cours de chargement"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Modules ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Choix multiples"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Réponses multiples"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Non trouvé"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Autre type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Pages ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Correspondance de modèle"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Points"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Précédent"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Questions"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "En cours d’envoi"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Cela pourrait prendre un certain temps selon la taille de la cartouche."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Vrai/Faux"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Sans titre"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Voir"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Voir Common Cartridge dans le navigateur. Ne nécessite aucun traitement du côté serveur."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Afficher Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Afficher la source sur Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Contenu d'un wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Vous êtes ici :"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "un téléversement de fichier"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (SCRO activé)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} questions"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} points"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0} %"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0} % chargé"

--- a/src/locales/ht/messages.po
+++ b/src/locales/ht/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: it\n"
+"Language: ht\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
@@ -15,173 +15,173 @@ msgstr ""
 
 #: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr "(non identificato)"
+msgstr "(non idantifye)"
 
 #: src/Resource.js:144
 msgid "All Items"
-msgstr "Tutti gli elementi"
+msgstr "Tout Eleman"
 
 #: src/Assessment.js:131
 msgid "Assessment"
-msgstr "Valutazione"
+msgstr "Evalyasyon"
 
 #: src/AssessmentList.js:43
 msgid "Assessments"
-msgstr "Valutazioni"
+msgstr "Evalyasyon"
 
 #: src/CommonCartridge.js:364
 msgid "Assessments ( {0})"
-msgstr "Valutazioni ( {0})"
+msgstr "Evalyasyon ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr "Valutazioni ({0})"
+#~ msgstr "Evalyasyon ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr "Compito"
+msgstr "Sesyon"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr "Compiti"
+msgstr "Sesyon"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr "Compiti ({0})"
+#~ msgstr "Sesyon ({0})"
 
 #: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr "Compiti ({numberOfAssignments})"
+msgstr "Sesyon ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr "Allegati"
+msgstr "Atachman"
 
 #: src/App.js:109
 msgid "Cartridge"
-msgstr "Cartuccia"
+msgstr "Katouch"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr "Fai clic qui per aprire il link in una nuova finestra"
+msgstr "Klike la pou ka ouvri lyen nan yon nouvo fenèt"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr "Discussione"
+msgstr "Diskisyon"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr "Discussioni"
+msgstr "Diskisyon"
 
 #: src/CommonCartridge.js:356
 msgid "Discussions ( {0})"
-msgstr "Discussioni ( {0})"
+msgstr "Diskisyon ( {0})"
 
 #: src/CommonCartridge.js:344
 #~ msgid "Discussions ({0})"
-#~ msgstr "Discussioni ({0})"
+#~ msgstr "Diskisyon ({0})"
 
 #: src/App.js:95
 msgid "Drag and drop, or click to browse your computer"
-msgstr "Trascina la selezione o fai clic per cercare nel tuo computer"
+msgstr "Deplase oswa klike pou ka navige sou òdinatè w la."
 
 #: src/Assessment.js:96
 msgid "Essay"
-msgstr "Saggio"
+msgstr "Redaksyon"
 
 #: src/App.js:135
 msgid "Examples"
-msgstr "Esempi"
+msgstr "Egzanp"
 
 #: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr "Anteprima non disponibile per il contenuto dello strumento esterno"
+msgstr "Paka wè Apèsi de Kontni Zouti Ekstèn yo "
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr "Link esterno"
+msgstr "Lyen Ekstèn"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr "File"
+msgstr "Fichye"
 
 #: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr "File ({0})"
+msgstr "Fichye ({0})"
 
 #: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr "Riempi gli spazi vuoti"
+msgstr "Ranpli espas vid"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr "Immagine"
+msgstr "Imaj"
 
 #: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr "Per utilizzare questa risorsa in Canvas, deve essere installato lo strumento esterno."
+msgstr "Pou w kapab itilize resous sa a ssssou Canvas, zouti ekstèn nan dwe enstale."
 
 #: src/Image.js:37
 msgid "Loading"
-msgstr "Caricamento"
+msgstr "Chajman"
 
 #: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr "Caricamento cartuccia"
+msgstr "Chajman Katouch"
 
 #: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr "Caricamento completato"
+msgstr "Fen chajman"
 
 #: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr "Moduli ({0})"
+msgstr "Modil ({0})"
 
 #: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr "Scelta multipla"
+msgstr "Plizyè chwa"
 
 #: src/Assessment.js:72
 msgid "Multiple response"
-msgstr "Risposta multipla"
+msgstr "Plizyè repons"
 
 #: src/Resource.js:127
 msgid "Next"
-msgstr "Successivo"
+msgstr "Pwochen"
 
 #: src/Resource.js:287
 msgid "Not found"
-msgstr "Non trovato"
+msgstr "Entwouvab"
 
 #: src/Assessment.js:102
 msgid "Other type"
-msgstr "Altro tipo"
+msgstr "Lòt tipp"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr "Pagina"
+msgstr "Paj"
 
 #: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr "Pagine ({0})"
+msgstr "Paj ({0})"
 
 #: src/Assessment.js:90
 msgid "Pattern match"
-msgstr "Corrispondenza motivo"
+msgstr "Korespondans modèl"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr "Punti"
+msgstr "Pwen"
 
 #: src/Resource.js:109
 msgid "Previous"
-msgstr "Precedente"
+msgstr "Anvan"
 
 #: src/Assessment.js:155
 msgid "Questions"
-msgstr "Domande"
+msgstr "Kesyon"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -189,15 +189,15 @@ msgstr "Domande"
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr "Invio"
+msgstr "Soumisyon"
 
 #: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr "Questo può richiedere un po’ di tempo in base alla dimensione della cartuccia."
+msgstr "Sa ka pran ti tan sa depan de gwosè katouch la."
 
 #: src/Assessment.js:78
 msgid "True / false"
-msgstr "Vero/falso"
+msgstr "Vrè / fo"
 
 #: src/CommonCartridge.js:325
 #: src/ModulesList.js:155
@@ -205,50 +205,50 @@ msgstr "Vero/falso"
 #: src/WebLinkListItem.js:24
 #: src/utils.js:203
 msgid "Untitled"
-msgstr "Senza titolo"
+msgstr "San tit"
 
 #: src/App.js:121
 msgid "View"
-msgstr "Visualizza"
+msgstr "Afiche"
 
 #: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr "Visualizzare cartucce Common nel browser. Non richiede alcuna elaborazione lato server."
+msgstr "Afiche Katouch Komen yo nan navigatè a. Li pa bezwen okenn tretman nan sèvè."
 
 #: src/App.js:93
 msgid "View a Common Cartridge (.imscc)"
-msgstr "Visualizza una cartuccia Common (.imscc)"
+msgstr "Afiche yon Katouch Komen (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr "Visualizza origine in Github"
+msgstr "Afiche sous nan Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr "Contenuto Wiki"
+msgstr "Kontni Wiki"
 
 #: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr "Sei qui:"
+msgstr "Ou la a:"
 
 #: src/utils.js:272
 msgid "a file upload"
-msgstr "un caricamento di file"
+msgstr "yon fichye transfè"
 
 #: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr "https://www.yourdomain.com/cartridge.imscc (CORS abilitato)"
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS aktive)"
 
 #: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr "{0} domande"
+msgstr "{0} Kesyon"
 
 #: src/AssessmentListItem.js:80
 #: src/AssignmentListItemBody.js:25
 #: src/DiscussionListItem.js:70
 #: src/FileListItem.js:68
 msgid "{0} points"
-msgstr "{0} punti"
+msgstr "{0} pwen"
 
 #: src/CommonCartridge.js:280
 msgid "{0}%"
@@ -256,4 +256,4 @@ msgstr "{0}%"
 
 #: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr "{0}% caricato"
+msgstr "{0}% chaje"

--- a/src/locales/is/messages.po
+++ b/src/locales/is/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(óþekkt)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Öll atriði"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Mat"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Möt"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Möt ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Möt ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Verkefni"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Verkefni"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Verkefni ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Verkefni ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Viðhengi"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Hylki"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Smelltu hér til að opna hlekk í nýjum glugga"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Umræða"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Umræður"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Umræður ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Umræður ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Dragðu og slepptu, eða smelltu til að vafra í tölvunni."
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Ritgerð"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Dæmi"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Ekki er hægt að forskoða efni ytra verkfæris"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Utanaðkomandi tengill"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Skrár"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Skrár ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Fylltu inn í eyðuna"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Mynd"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Til þess að nota þetta hjálparefni í Canvas þarf að setja upp ytra verkfæri."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Sæki"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Hleð inn hylki"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Hleð inn fullnustu"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Eining ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Fjölval"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Fjölsvar"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Næsti"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Fannst ekki"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Önnur gerð"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Síða"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Síður ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Mynstursamsvörun"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Punktar"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Fyrri"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Spurningar"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Legg fram"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Þetta getur tekið smá tíma en það fer eftir stærð hylkisins."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Rétt/rangt"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Án titils"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Skoða"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Skoða Common Cartridges í vafranum. Krefst engrar vinnslu miðlaramegin."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Skoða Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Skoða uppruna á Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki efni"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Þú ert hérna:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "upphleðsla skrár"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} spurningar"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} punktar"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% hlaðið"

--- a/src/locales/ja/messages.po
+++ b/src/locales/ja/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:31-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(未確認)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "すべてのアイテム"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "アセスメント"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "アセスメント"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "アセスメント ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "アセスメント ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "課題"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "課題"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "課題 ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "課題 ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "添付ファイル"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "カートリッジ"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "ここをクリックして新しいウィンドウでリンクを開く"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "ディスカッション"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "ディスカッション"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "ディスカッション ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "ディスカッション ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "ドラッグアンドドロップまたはクリックしてコンピュータを参照"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "エッセイ（小論文）"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "例"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "外部ツールのコンテンツをプレビューできません"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "外部リンク"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "ファイル"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "ファイル ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "空欄を埋める"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "画像"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Canvas 内でこのリソースを使用するには、外部ツールをインストールする必要があります。"
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "読み込み中"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "カートリッジ読み込み中"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "読み込み完了"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "モジュール ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "複数選択肢"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "複数の回答"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "次"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "見つかりません"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "その他のタイプ"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "ページ"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "ページ ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "パターンマッチ"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "ポイント"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "前"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "質問"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "提出しています"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "カートリッジのサイズに応じて、これには時間がかかることがあります。"
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "正/誤"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "無題"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "表示"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "ブラウザで共通のカートリッジを表示します。 サーバー側の処理は不要です。"
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "共通カートリッジ（.imscc）を表示する"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Github のソースを表示"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki コンテンツ"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "あなたの現在地："
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "ファイルのアップロード"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS 有効)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0}の質問"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} 点"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% 読み込み済み"

--- a/src/locales/mi/messages.po
+++ b/src/locales/mi/messages.po
@@ -5,7 +5,7 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
-"Language: it\n"
+"Language: mi\n"
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
@@ -15,173 +15,173 @@ msgstr ""
 
 #: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr "(non identificato)"
+msgstr "(kaore e mōhiotia)"
 
 #: src/Resource.js:144
 msgid "All Items"
-msgstr "Tutti gli elementi"
+msgstr "Ngā Tūemi katoa"
 
 #: src/Assessment.js:131
 msgid "Assessment"
-msgstr "Valutazione"
+msgstr "aromatawai"
 
 #: src/AssessmentList.js:43
 msgid "Assessments"
-msgstr "Valutazioni"
+msgstr "Ngā aromatawai"
 
 #: src/CommonCartridge.js:364
 msgid "Assessments ( {0})"
-msgstr "Valutazioni ( {0})"
+msgstr "Ngā Aromatawai ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr "Valutazioni ({0})"
+#~ msgstr "Ngā Aromatawai ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr "Compito"
+msgstr "Whakataunga"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr "Compiti"
+msgstr "Ngā whakataunga"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr "Compiti ({0})"
+#~ msgstr "Ngā Whakataunga ({0})"
 
 #: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr "Compiti ({numberOfAssignments})"
+msgstr "Ngā Whakataunga ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr "Allegati"
+msgstr "Ngā Āpititanga"
 
 #: src/App.js:109
 msgid "Cartridge"
-msgstr "Cartuccia"
+msgstr "Porohita"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr "Fai clic qui per aprire il link in una nuova finestra"
+msgstr "Pāwhiri ki konei ki te huaki i te matapihi hou"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr "Discussione"
+msgstr "Kōrerorero"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr "Discussioni"
+msgstr "Ngā Kōrerorero"
 
 #: src/CommonCartridge.js:356
 msgid "Discussions ( {0})"
-msgstr "Discussioni ( {0})"
+msgstr "Ngā Kōrerorero ( {0})"
 
 #: src/CommonCartridge.js:344
 #~ msgid "Discussions ({0})"
-#~ msgstr "Discussioni ({0})"
+#~ msgstr "Ngā Kōrerorero ({0})"
 
 #: src/App.js:95
 msgid "Drag and drop, or click to browse your computer"
-msgstr "Trascina la selezione o fai clic per cercare nel tuo computer"
+msgstr "Tō me te whakataka, pāwhiri rānei ki te tirotiro tō rorohiko"
 
 #: src/Assessment.js:96
 msgid "Essay"
-msgstr "Saggio"
+msgstr "Tuhinga roa"
 
 #: src/App.js:135
 msgid "Examples"
-msgstr "Esempi"
+msgstr "Ngā tauira"
 
 #: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr "Anteprima non disponibile per il contenuto dello strumento esterno"
+msgstr "Taputapu o waho Ihirangi kaore e taea te arokite"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr "Link esterno"
+msgstr "Hono o waho"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr "File"
+msgstr "Ngā kōnae"
 
 #: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr "File ({0})"
+msgstr "Ngā kōnae ({0})"
 
 #: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr "Riempi gli spazi vuoti"
+msgstr "Whakakī i te kore"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr "Immagine"
+msgstr "Āhua"
 
 #: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr "Per utilizzare questa risorsa in Canvas, deve essere installato lo strumento esterno."
+msgstr "Hei whakamahi i tēnei rauemi ki Canvas, me whakauru te taputapu o waho."
 
 #: src/Image.js:37
 msgid "Loading"
-msgstr "Caricamento"
+msgstr "E tukuake ana"
 
 #: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr "Caricamento cartuccia"
+msgstr "E tukuake ana porohita ana"
 
 #: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr "Caricamento completato"
+msgstr "Kua oti te tukuake"
 
 #: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr "Moduli ({0})"
+msgstr "Ngā kōwae ({0})"
 
 #: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr "Scelta multipla"
+msgstr "Kōwhiringa maha"
 
 #: src/Assessment.js:72
 msgid "Multiple response"
-msgstr "Risposta multipla"
+msgstr "Whakautu maha"
 
 #: src/Resource.js:127
 msgid "Next"
-msgstr "Successivo"
+msgstr "E haere ake nei"
 
 #: src/Resource.js:287
 msgid "Not found"
-msgstr "Non trovato"
+msgstr "Kaore e kitea"
 
 #: src/Assessment.js:102
 msgid "Other type"
-msgstr "Altro tipo"
+msgstr "Tētahi atu momo"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr "Pagina"
+msgstr "Whārangi"
 
 #: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr "Pagine ({0})"
+msgstr "Ngā Whārangi ({0})"
 
 #: src/Assessment.js:90
 msgid "Pattern match"
-msgstr "Corrispondenza motivo"
+msgstr "Tauira ōrite"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr "Punti"
+msgstr "Ngā koinga"
 
 #: src/Resource.js:109
 msgid "Previous"
-msgstr "Precedente"
+msgstr "ō muri"
 
 #: src/Assessment.js:155
 msgid "Questions"
-msgstr "Domande"
+msgstr "Ngā pātai"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -189,15 +189,15 @@ msgstr "Domande"
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr "Invio"
+msgstr "E tuku ana"
 
 #: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr "Questo può richiedere un po’ di tempo in base alla dimensione della cartuccia."
+msgstr "Ka āhua roa pea tēnei wā i runga i te rahi o te porohita."
 
 #: src/Assessment.js:78
 msgid "True / false"
-msgstr "Vero/falso"
+msgstr "Pono/Rūkahau"
 
 #: src/CommonCartridge.js:325
 #: src/ModulesList.js:155
@@ -205,50 +205,50 @@ msgstr "Vero/falso"
 #: src/WebLinkListItem.js:24
 #: src/utils.js:203
 msgid "Untitled"
-msgstr "Senza titolo"
+msgstr "Taitara kore"
 
 #: src/App.js:121
 msgid "View"
-msgstr "Visualizza"
+msgstr "Tirohia"
 
 #: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr "Visualizzare cartucce Common nel browser. Non richiede alcuna elaborazione lato server."
+msgstr "Tirohia ngā Porohita Common i roto  i te pūtirotiro. Kaore e hiahiatia he tūmau-taha tukatuka."
 
 #: src/App.js:93
 msgid "View a Common Cartridge (.imscc)"
-msgstr "Visualizza una cartuccia Common (.imscc)"
+msgstr "Tirohia he Common Porohita (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr "Visualizza origine in Github"
+msgstr "Tirohia puna i runga ō Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr "Contenuto Wiki"
+msgstr "Wiki ihirangi"
 
 #: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr "Sei qui:"
+msgstr "Kei konei koe:"
 
 #: src/utils.js:272
 msgid "a file upload"
-msgstr "un caricamento di file"
+msgstr "he tukunga ake kōnae"
 
 #: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr "https://www.yourdomain.com/cartridge.imscc (CORS abilitato)"
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
 
 #: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr "{0} domande"
+msgstr "{0} Pātai"
 
 #: src/AssessmentListItem.js:80
 #: src/AssignmentListItemBody.js:25
 #: src/DiscussionListItem.js:70
 #: src/FileListItem.js:68
 msgid "{0} points"
-msgstr "{0} punti"
+msgstr "{0} ng ākoinga"
 
 #: src/CommonCartridge.js:280
 msgid "{0}%"
@@ -256,4 +256,4 @@ msgstr "{0}%"
 
 #: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr "{0}% caricato"
+msgstr "{0}% kua utaina"

--- a/src/locales/nb/messages.po
+++ b/src/locales/nb/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(Ikke identifisert)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Alle elementer"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Vurdering"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Vurderinger"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Vurderinger ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Vurderinger ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Oppgave"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Oppgaver"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Oppgaver ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Oppgaver ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Vedlegg"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Eske"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Trykk her for å åpne lenke i nytt vindu"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Diskusjon"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Diskusjoner"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Diskusjoner ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Diskusjoner ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Dra og slipp, eller trykk for å bla i din datamaskin"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Essay"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Eksempler"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Eksterne verktøy-innhold kan ikke forhåndsvises"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Ekstern lenke"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Filer"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Filer ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Fyll ut det tomme feltet"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Bilde"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "For å kunne bruke denne ressursen i Canvas, må eksterne verktøy være installert."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Laster"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Laster Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Laster ferdig"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Moduler ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Flere valgmuligheter"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Flere svar"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Neste"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Ikke funnet"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Annen type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Side"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Sider ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Pattern Match"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Poeng"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Forrige"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Spørsmål"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Må leveres"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Dette kan ta litt tid, avhengig av størrelsen på Cartridge."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Sant / usant"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Uten navn"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Vis"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Vis Common Cartridge i en nettleser. Krever ingen behandling fra server-side."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Vis en Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Vis Github-kilde"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki-innhold"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Du er her:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "en filopplasting"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS aktivert)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} spørsmål"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} poeng"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% lastet"

--- a/src/locales/nl/messages.po
+++ b/src/locales/nl/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(niet-geïdentificeerd)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Alle items"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Beoordeling"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Beoordelingen"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Beoordelingen ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Beoordelingen ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Opdracht"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Opdrachten"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Opdrachten ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Opdrachten ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Bijlagen"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Klik hier om de link te openen in een nieuw venster"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussie"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussies"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussies ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussies ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Slepen en neerzetten, of klikken om je computer te doorzoeken"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Verhandeling"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Voorbeelden"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Er kan geen voorbeeld worden weergeven van de inhoud van de externe tool"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Externe link"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Bestanden"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Bestanden ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Vul de blanco ruimte in"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Afbeelding"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Om deze bron in Canvas te kunnen gebruiken, moet de externe tool zijn geïnstalleerd."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Bezig met laden"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Cartridge laden"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Laden voltooid"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Modules ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Meerkeuze"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Meerdere antwoorden"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Volgende"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Niet aangetroffen"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Ander type"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Pagina"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Pagina's ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Patroonovereenkomst"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Punten"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Vorige"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Vragen"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "In te leveren"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Dit kan even duren afhankelijk van de grootte van de cartridge."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Waar/Onwaar"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Zonder titel"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Weergeven"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Bekijk Common Cartridges in de browser. Hiervoor is geen verwerking aan de serverzijde vereist."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Een Common Cartridge (.imscc) bekijken"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Bron bekijken op Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki-inhoud"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Je bent hier:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "een bestandsupload"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS ingeschakeld)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} vragen"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} punten"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% geladen"

--- a/src/locales/pl/messages.po
+++ b/src/locales/pl/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(niezidentyfikowano)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Wszystkie pozycje"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Test"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Testy"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Testy ({0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Testy ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Zadanie"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Zadania"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Zadania ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Zadania ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Załączniki"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Wkład"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Kliknij tutaj, aby otworzyć łącze w nowym oknie"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Dyskusja"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Dyskusje"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Dyskusje ({0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Dyskusje ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Przeciągnij i upuść lub kliknij, aby przeglądać komputer"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Esej"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Przykłady"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Dla zewnętrznej zawartości narzędzia nie ma podglądu"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Łącze zewnętrzne"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Pliki"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Pliki ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Uzupełnij puste pola"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Zdjęcie"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Aby korzystać z tego zasobu w Canvas, należy zainstalować zewnętrzne narzędzie."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Wczytywanie"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Wczytywanie wkładu"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Zakończono wczytywanie"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Moduły ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Wielokrotny wybór"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Wiele odpowiedzi"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Następny"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Nie znaleziono"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Inny typ"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Strona"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Strony ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Dopasuj do wzorca"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Punkty"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Poprzednie"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Pytania"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Przesyłanie"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Może to trochę potrwać; zależy od rozmiaru wkładu."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Prawda/fałsz"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Bez tytułu"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Wyświetl"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Wyświetl typowe wkłady w tej przeglądarce. Nie wymaga przetwarzania po stronie serwera."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Wyświetl typowy wkład (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Wyświetl źródło na Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Zawartość wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Jesteś tutaj:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "przekazywanie pliku"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (włączono CORS)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "Pytania: {0}"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} punkty"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% wczytano"

--- a/src/locales/pt/messages.po
+++ b/src/locales/pt/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(não identificado)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Todos os itens"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Avaliação"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Avaliações"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Avaliações ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Avaliações ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Tarefa"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Tarefas"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Tarefas ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Tarefas ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Anexos"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartucho"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Clique aqui para abrir a ligação em uma nova janela"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussão"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussões"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussões ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussões ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Arraste e solte ou clique para navegar no seu computador"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Redação"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Exemplos"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "O conteúdo da ferramenta externa não pode ser visualizado"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Ligação externa"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Ficheiros"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Ficheiros ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Preencha o espaço em branco"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Imagem"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Para usar este recurso no Canvas, a ferramenta externa deve estar instalada."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "A carregar"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "A carregar Cartucho"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Conclusão do carregamento"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Módulos ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Múltipla escolha"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Resposta Múltipla"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Próximo"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Não encontrado"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Outro tipo"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Página"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Páginas ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Jogo padrão"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Pontos"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Perguntas"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "A enviar"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Isso pode levar algum tempo, dependendo do tamanho do cartucho."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Verdadeiro / falso"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Sem título"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Ver"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Ver Cartuchos Comuns no navegador. Não requer processamento no lado do servidor."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Ver um cartucho comum (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Ver fonte no Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Conteúdo wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Você está aqui:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "um envio de ficheiro"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS ativado)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Questões"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} pontos"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% carregado"

--- a/src/locales/pt_BR/messages.po
+++ b/src/locales/pt_BR/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(sem identificação)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Todos os Itens"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Avaliação"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Avaliações"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Avaliações ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Avaliações ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Tarefa"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Tarefas"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Tarefas ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Tarefas ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Anexos"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Clique aqui para abrir o link na nova janela"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Discussão"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussões"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Discussões ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Discussões ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Arraste e solte ou clique para navegar no seu computador"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Redação"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Exemplos"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Conteúdo da ferramenta externa não pode ser visualizado"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Link externo"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Arquivos"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Arquivo ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Preencher a lacuna"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Imagem"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Para usar este recurso no Canvas, a ferramenta externa deve ser instalada."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Carregando"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Carregando Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Conclusão do carregamento"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Módulos ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Múltipla escolha"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Múltipla resposta"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Próximo"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Não encontrado"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Outro tipo"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Página"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Páginas ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Correspondência de Padrão"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Pontos"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Anterior"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Perguntas"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Enviando"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Isso pode levar algum tempo dependendo do tamanho do cartridge."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Verdadeiro/Falso"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Sem título"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Visualizar"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Visualize Common Cartridges no navegador. Não exige processamento do servidor."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Visualizar um Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Visualizar fonte no Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Conteúdo Wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Você está aqui:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "um upload de arquivo"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS habilitado)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} perguntas"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} pontos"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% carregado"

--- a/src/locales/ru/messages.po
+++ b/src/locales/ru/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(неопределенный)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Все элементы"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Тестирование"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Тестирования"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Тестирования ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Тестирования ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Задание"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Задания"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Задания ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Задания ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Вложения"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Нажмите здесь, чтобы открыть ссылку в новом окне"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Обсуждение"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Обсуждения"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Обсуждения ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Обсуждения ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Перетащите или щелкните, чтобы просмотреть свой компьютер"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Тест"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Примеры"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Контент внешнего инструмента не может быть предварительно просмотрен"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Внешняя ссылка"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Файлы"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Файлы ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Заполните пустое место"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Изображение"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Чтобы использовать этот ресурс в Canvas, необходимо установить внешний инструмент."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Загрузка"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Загружается Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Завершение загрузки"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Модули ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Множественный выбор"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Множественный ответ"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Далее"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Не найдено"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Другой тип"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Страница"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Страницы ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Сопоставление с образцом"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Баллы"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Предыдущий"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Вопросы"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Отправка"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Это может занять некоторое время в зависимости от размера картриджа."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Верно / Неверно"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Без названия"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Просмотр"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Просмотр общих картриджей в браузере. Не требует обработки на стороне сервера."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Посмотреть общий картридж (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Просмотреть источник на Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Контент Wiki"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Вы находитесь здесь:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "загрузка файла"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS включен)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} вопросов"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} баллов"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% загружено"

--- a/src/locales/sv/messages.po
+++ b/src/locales/sv/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "(ej identifierad)"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "Alla föremål"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "Bedömning"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "Bedömningar"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "Bedömningar ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "Bedömningar ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "Uppgift"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "Uppgifter"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "Uppgifter ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "Uppgifter ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "Bilagor"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Patron"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "Klicka här för att öppna länken i ett nytt fönster"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "Diskussion"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "Discussions"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "Diskussioner ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "Diskussioner ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "Dra och släpp, eller klicka för att söka i din dator"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "Uppsats"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "Exempel"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "Innehåll i extern verktyg kan inte förhandsvisas"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "Extern länk"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "Filer"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "Filer ({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "Fyll i tomma rutor"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "Bild"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "Det externa verktyget måste installeras för att du ska kunna använda den här resursen i Canvas."
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "Läser in"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "Läser in patron"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "Inläsning slutförd"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "Moduler ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "Flerval"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "Flera svar"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "Nästa"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "Hittades inte"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "Annan typ"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "Sida"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "Sidor ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "Mönstermatchning"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "Poäng"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "Föregående"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "Frågor"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "Lämnar in"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "Detta kan ta lite tid beroende på patronens storlek."
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "Sant/falskt"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "Namnlös"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "Visa"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "Visa Common Cartridge i webbläsaren. Kräver inte behandling på servern."
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "Visa en Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "Visa källa på Github"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki-innehåll"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "Du är här:"
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "en filuppladdning"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc (CORS-aktiverad)"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} Frågor"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} poäng"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "{0}% har lästs in"

--- a/src/locales/zh/messages.po
+++ b/src/locales/zh/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "（无法识别）"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "所有项目"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "评估"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "评估"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "评估 ( {0})"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "评估 ({0})"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "作业"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "作业"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "作业 ({0})"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "作业 ({numberOfAssignments})"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "附件"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "点击此处在新窗口中打开链接"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "讨论"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "讨论"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "讨论 ( {0})"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "讨论 ({0})"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "拖放或点击以浏览计算机"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "论文"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "示例"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "无法预览外部工具内容"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "外部链接"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "文件"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "文件({0})"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "填写空白处"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "图片"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "要在 Canvas 中使用此资源，必须安装外部工具。"
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "正在加载"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "正在加载 Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "加载完成"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "单元 ({0})"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "多选"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "多个答案"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "下一步"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "找不到"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "其他类型"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "页面"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "页面 ({0})"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "样式匹配"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "得分"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "上一个"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "问题"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "提交"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "这可能需要一些时间，具体取决于 cartridge 的大小。"
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "对/错"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "无标题"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "查看"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "在浏览器中查看 Common Cartridge。要求无服务器在运行处理任务。"
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "查看 Common Cartridge (.imscc)"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "在 Github 上查看源"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "Wiki 内容"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "您在此处："
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "一份上传文件"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc（启用 CORS）"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} 个问题"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} 分"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "已加载{0}%"

--- a/src/locales/zh_HK/messages.po
+++ b/src/locales/zh_HK/messages.po
@@ -1,6 +1,6 @@
-msgid ""
+﻿msgid ""
 msgstr ""
-"POT-Creation-Date: 2018-12-06 10:32-0700\n"
+"POT-Creation-Date: 2018-12-04 10:02-0700\n"
 "Mime-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -13,246 +13,175 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/ModulesList.js:179
+#: src/ModulesList.js:156
 msgid "(unidentified)"
-msgstr ""
+msgstr "（未定義）"
 
-#: src/Resource.js:151
-#~ msgid "All Items"
-#~ msgstr ""
+#: src/Resource.js:144
+msgid "All Items"
+msgstr "所有項目"
 
 #: src/Assessment.js:131
-#~ msgid "Assessment"
-#~ msgstr ""
+msgid "Assessment"
+msgstr "評估"
 
 #: src/AssessmentList.js:43
-#~ msgid "Assessments"
-#~ msgstr ""
+msgid "Assessments"
+msgstr "評估"
 
 #: src/CommonCartridge.js:364
-#~ msgid "Assessments ( {0})"
-#~ msgstr ""
+msgid "Assessments ( {0})"
+msgstr "評估（{0}）"
 
 #: src/CommonCartridge.js:352
 #~ msgid "Assessments ({0})"
-#~ msgstr ""
+#~ msgstr "評估（{0}）"
 
 #: src/AssignmentBody.js:23
 msgid "Assignment"
-msgstr ""
+msgstr "作業"
 
 #: src/AssignmentList.js:34
 #: src/AssociatedContentAssignmentList.js:34
 msgid "Assignments"
-msgstr ""
+msgstr "作業列表"
 
 #: src/CommonCartridge.js:330
 #~ msgid "Assignments ({0})"
-#~ msgstr ""
+#~ msgstr "作業列表（{0}）"
 
-#: src/CommonCartridge.js:368
+#: src/CommonCartridge.js:344
 msgid "Assignments ({numberOfAssignments})"
-msgstr ""
+msgstr "作業列表（{numberOfAssignments}）"
 
 #: src/AssignmentBody.js:66
 #: src/Discussion.js:57
 msgid "Attachments"
-msgstr ""
+msgstr "附件"
 
-#: src/Assessment.js:167
-msgid "Calculated"
-msgstr ""
-
-#: src/App.js:122
+#: src/App.js:109
 msgid "Cartridge"
-msgstr ""
+msgstr "Cartridge"
 
 #: src/WebLink.js:40
 msgid "Click here to open link in new window"
-msgstr ""
-
-#: src/App.js:106
-msgid "Common Cartridge Viewer"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:11
-msgid "Course Navigation Cannot Be Previewed"
-msgstr ""
-
-#: src/CourseNavigationUnavailable.js:13
-msgid "Course navigation links are only available within a Canvas course."
-msgstr ""
+msgstr "按此於新視窗內開啟連結"
 
 #: src/Discussion.js:40
 msgid "Discussion"
-msgstr ""
+msgstr "討論"
 
 #: src/DiscussionList.js:41
 msgid "Discussions"
-msgstr ""
+msgstr "討論區"
 
 #: src/CommonCartridge.js:356
-#~ msgid "Discussions ( {0})"
-#~ msgstr ""
+msgid "Discussions ( {0})"
+msgstr "討論區（{0}）"
 
-#: src/CommonCartridge.js:380
-msgid "Discussions ({0})"
-msgstr ""
-
-#: src/App.js:108
-msgid "Drag and drop the cartridge, or click to browse your computer."
-msgstr ""
+#: src/CommonCartridge.js:344
+#~ msgid "Discussions ({0})"
+#~ msgstr "討論區（{0}）"
 
 #: src/App.js:95
-#~ msgid "Drag and drop, or click to browse your computer"
-#~ msgstr ""
+msgid "Drag and drop, or click to browse your computer"
+msgstr "拖放或點擊以瀏覽您的電腦"
 
-#: src/Assessment.js:155
+#: src/Assessment.js:96
 msgid "Essay"
-msgstr ""
+msgstr "論文"
 
-#: src/App.js:148
+#: src/App.js:135
 msgid "Examples"
-msgstr ""
+msgstr "範例"
 
-#: src/PreviewUnavailable.js:11
+#: src/PreviewUnavailable.js:18
 msgid "External Tool Content Can't be Previewed"
-msgstr ""
+msgstr "不能預覽外部工具內容"
 
 #: src/WebLink.js:29
 msgid "External link"
-msgstr ""
-
-#: src/CommonCartridge.js:260
-msgid "Failed to load resource"
-msgstr ""
-
-#: src/Assessment.js:173
-msgid "File Upload"
-msgstr ""
+msgstr "外部連結"
 
 #: src/FileList.js:38
 msgid "Files"
-msgstr ""
+msgstr "檔案"
 
-#: src/CommonCartridge.js:398
+#: src/CommonCartridge.js:372
 msgid "Files ({0})"
-msgstr ""
+msgstr "檔案（{0}）"
 
-#: src/Assessment.js:149
+#: src/Assessment.js:84
 msgid "Fill in the blank"
-msgstr ""
+msgstr "填空"
 
 #: src/Image.js:55
 msgid "Image"
-msgstr ""
+msgstr "圖像"
 
-#: src/PreviewUnavailable.js:13
+#: src/PreviewUnavailable.js:23
 msgid "In order to use this resource in Canvas, the external tool must be installed."
-msgstr ""
+msgstr "必須安裝外部工具以在 Canvas 內使用此資源。"
 
-#: src/EmbeddedPreview.js:59
 #: src/Image.js:37
 msgid "Loading"
-msgstr ""
+msgstr "正在載入"
 
-#: src/CommonCartridge.js:278
+#: src/CommonCartridge.js:254
 msgid "Loading Cartridge"
-msgstr ""
+msgstr "正在載入 Cartridge"
 
-#: src/CommonCartridge.js:295
+#: src/CommonCartridge.js:271
 msgid "Loading completion"
-msgstr ""
+msgstr "完成載入"
 
-#: src/Assessment.js:161
-msgid "Match Questions"
-msgstr ""
-
-#: src/Assessment.js:241
-msgid "Max attempts"
-msgstr ""
-
-#: src/EmbeddedPreview.js:71
-#: src/EmbeddedPreview.js:80
-#: src/EmbeddedPreview.js:90
-msgid "Media viewer"
-msgstr ""
-
-#: src/CommonCartridge.js:363
+#: src/CommonCartridge.js:339
 msgid "Modules ({0})"
-msgstr ""
+msgstr "單元（{0}）"
 
-#: src/Assessment.js:158
-msgid "Multiple Dropdowns"
-msgstr ""
-
-#: src/Assessment.js:140
+#: src/Assessment.js:66
 msgid "Multiple choice"
-msgstr ""
+msgstr "多項選擇"
 
-#: src/Assessment.js:143
+#: src/Assessment.js:72
 msgid "Multiple response"
-msgstr ""
+msgstr "多項回答"
 
-#: src/Resource.js:129
+#: src/Resource.js:127
 msgid "Next"
-msgstr ""
+msgstr "下一個"
 
 #: src/Resource.js:287
-#~ msgid "Not found"
-#~ msgstr ""
-
-#: src/Assessment.js:164
-msgid "Numerical"
-msgstr ""
+msgid "Not found"
+msgstr "未找到"
 
 #: src/Assessment.js:102
-#~ msgid "Other type"
-#~ msgstr ""
+msgid "Other type"
+msgstr "其他類型"
 
 #: src/WikiContent.js:25
 msgid "Page"
-msgstr ""
+msgstr "頁面"
 
-#: src/CommonCartridge.js:373
+#: src/CommonCartridge.js:349
 msgid "Pages ({0})"
-msgstr ""
+msgstr "頁面（{0}）"
 
-#: src/Assessment.js:152
+#: src/Assessment.js:90
 msgid "Pattern match"
-msgstr ""
+msgstr "類近題型"
 
 #: src/AssignmentBody.js:48
 msgid "Points"
-msgstr ""
+msgstr "分數"
 
-#: src/Resource.js:108
+#: src/Resource.js:109
 msgid "Previous"
-msgstr ""
+msgstr "上一個"
 
-#: src/Assessment.js:256
+#: src/Assessment.js:155
 msgid "Questions"
-msgstr ""
-
-#: src/Assessment.js:228
-msgid "Quiz"
-msgstr ""
-
-#: src/AssessmentList.js:43
-msgid "Quizzes"
-msgstr ""
-
-#: src/CommonCartridge.js:389
-msgid "Quizzes ({0})"
-msgstr ""
-
-#: src/CommonCartridge.js:376
-#~ msgid "Quizzes ({numberOfAssessment})"
-#~ msgstr ""
-
-#: src/ResourceUnavailable.js:11
-msgid "Resource Unavailable"
-msgstr ""
+msgstr "問題"
 
 #: src/Assignment.js:61
 #~ msgid "Submission formats"
@@ -260,100 +189,71 @@ msgstr ""
 
 #: src/AssignmentBody.js:35
 msgid "Submitting"
-msgstr ""
+msgstr "提交"
 
-#: src/Assessment.js:170
-msgid "Text only"
-msgstr ""
-
-#: src/CommonCartridge.js:286
+#: src/CommonCartridge.js:262
 msgid "This may take some time depending on the size of the cartridge."
-msgstr ""
+msgstr "這可能需要一些時間，所需時間取決於 Cartridge 的大小。"
 
-#: src/ResourceUnavailable.js:12
-msgid "This resource is not included in the package."
-msgstr ""
-
-#: src/Assessment.js:146
+#: src/Assessment.js:78
 msgid "True / false"
-msgstr ""
+msgstr "正確/錯誤"
 
-#: src/CommonCartridge.js:349
-#: src/ExternalToolListItem.js:26
-#: src/ModulesList.js:178
+#: src/CommonCartridge.js:325
+#: src/ModulesList.js:155
 #: src/WebLink.js:36
-#: src/WebLinkListItem.js:30
-#: src/utils.js:250
+#: src/WebLinkListItem.js:24
+#: src/utils.js:203
 msgid "Untitled"
-msgstr ""
+msgstr "無標題"
 
-#: src/App.js:134
+#: src/App.js:121
 msgid "View"
-msgstr ""
+msgstr "檢視"
 
-#: src/App.js:141
+#: src/App.js:128
 msgid "View Common Cartridges in the browser. Requires no server-side processing."
-msgstr ""
+msgstr "在瀏覽器內檢視 Common Cartridge。不需伺服器側處理。"
 
 #: src/App.js:93
-#~ msgid "View a Common Cartridge (.imscc)"
-#~ msgstr ""
+msgid "View a Common Cartridge (.imscc)"
+msgstr "檢視 Common Cartridge（.imscc）"
 
 #: src/GitHubCorner.js:14
 msgid "View source on Github"
-msgstr ""
-
-#: src/CommonCartridge.js:262
-msgid "We had a problem loading the Common Cartridge"
-msgstr ""
+msgstr "在 Github 檢視資源"
 
 #: src/WikiContentList.js:60
 msgid "Wiki content"
-msgstr ""
+msgstr "維基內容"
 
-#: src/CommonCartridge.js:347
+#: src/CommonCartridge.js:323
 msgid "You are here:"
-msgstr ""
+msgstr "您在此："
 
-#: src/EmbeddedPreview.js:73
-msgid "Your browser doesn't support HTML5 audio. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/EmbeddedPreview.js:82
-msgid "Your browser doesn't support HTML5 video. Here is a <0>link to the audio</0> instead."
-msgstr ""
-
-#: src/utils.js:352
+#: src/utils.js:272
 msgid "a file upload"
-msgstr ""
+msgstr "檔案上傳"
 
-#: src/App.js:127
+#: src/App.js:114
 msgid "https://www.yourdomain.com/cartridge.imscc (CORS enabled)"
-msgstr ""
+msgstr "https://www.yourdomain.com/cartridge.imscc（已啟用 CORS）"
 
-#: src/AssessmentListItem.js:78
+#: src/AssessmentListItem.js:73
 msgid "{0} Questions"
-msgstr ""
+msgstr "{0} 個問題"
 
-#: src/WorkflowStateIcon.js:30
-msgid "{0} is published"
-msgstr ""
-
-#: src/WorkflowStateIcon.js:21
-msgid "{0} is unpublished"
-msgstr ""
-
-#: src/AssessmentListItem.js:85
-#: src/AssignmentListItemBody.js:30
-#: src/DiscussionListItem.js:75
-#: src/FileListItem.js:74
+#: src/AssessmentListItem.js:80
+#: src/AssignmentListItemBody.js:25
+#: src/DiscussionListItem.js:70
+#: src/FileListItem.js:68
 msgid "{0} points"
-msgstr ""
+msgstr "{0} 分"
 
-#: src/CommonCartridge.js:304
+#: src/CommonCartridge.js:280
 msgid "{0}%"
-msgstr ""
+msgstr "{0}%"
 
-#: src/CommonCartridge.js:298
+#: src/CommonCartridge.js:274
 msgid "{0}% loaded"
-msgstr ""
+msgstr "已載入 {0}%"


### PR DESCRIPTION
Fixes CM-607

We've got the translations back - let's add those to the project

Test Plan:
- npm run build
- Provide a locale code other than "en"
- Confirm that the app uses the translations