### PR TITLE
Offers to download when the embedded preview fails

### DIFF
--- a/src/EmbeddedPreview.js
+++ b/src/EmbeddedPreview.js
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
+
 import Spinner from "@instructure/ui-elements/lib/components/Spinner";
+
 import { I18n } from "@lingui/react";
 import { Trans, t } from "@lingui/macro";
 import { getExtension } from "./utils";
@@ -30,6 +32,7 @@ export default class EmbeddedPreview extends Component {
 
   handleMessage = event => {
     if (event.data == null || event.data[0] !== "{") {
+      this.props.onFail();
       return;
     }
     let response;
@@ -37,9 +40,11 @@ export default class EmbeddedPreview extends Component {
       response = JSON.parse(event.data);
     } catch (error) {
       console.warn("Error parsing data from postMessage");
+      this.props.onFail();
       return;
     }
     if (response.type !== "externalViewerResponse") {
+      this.props.onFail();
       return;
     }
     if (response.body.url) {

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -31,7 +31,8 @@ export default class Resource extends Component {
     super(props);
     this.state = {
       isLoaded: false,
-      isNotFound: false
+      isNotFound: false,
+      embeddedPreviewFailed: false
     };
   }
 
@@ -224,7 +225,8 @@ export default class Resource extends Component {
         ...DOCUMENT_PREVIEW_EXTENSIONS_SUPPORTED,
         ...NOTORIOUS_EXTENSIONS_SUPPORTED
       ].includes(extension) &&
-      this.props.externalViewer != null;
+      this.props.externalViewer != null &&
+      !this.state.embeddedPreviewFailed;
 
     let componentToRender;
     if (isImage) {
@@ -252,7 +254,12 @@ export default class Resource extends Component {
       );
     } else if (isDocumentWithPreview) {
       componentToRender = (
-        <EmbeddedPreview externalViewer={this.props.externalViewer} />
+        <EmbeddedPreview
+          onFail={() => (
+            this.setState({embeddedPreviewFailed: true})
+          )}
+          externalViewer={this.props.externalViewer}
+        />
       );
     } else if (components[type] != null) {
       componentToRender = components[type];
@@ -298,6 +305,7 @@ export default class Resource extends Component {
     const currentIndex = moduleItems.findIndex(item => `${item.href}` === href);
     const previousItem = currentIndex > -1 && moduleItems[currentIndex - 1];
     const nextItem = currentIndex > -1 && moduleItems[currentIndex + 1];
+
     return (
       <React.Fragment>
         {this.props.isModuleItem && (previousItem || nextItem) && (

--- a/tests/test.content-nav.js
+++ b/tests/test.content-nav.js
@@ -66,7 +66,7 @@ test("Previous and Next work with external tool items", async t => {
     .expect(previousButton.exists)
     .ok()
     .click(previousButton)
-    .expect(Selector("div").withAttribute("data-uid", "Spinner").exists)
+    .expect(Selector("span").withText("Download sample-document.pdf").exists)
     .ok();
 });
 


### PR DESCRIPTION
fixes [CM-696](https://instructure.atlassian.net/browse/CM-696)

testplan:
- open: [http://viewer.ccv.docker/?manifest=/test-cartridges/course-1/imsmanifest.xml#/resources/fbac4bef75744d02b353abc6451e2b16](http://viewer.ccv.docker/?manifest=/test-cartridges/course-1/imsmanifest.xml#/resources/fbac4bef75744d02b353abc6451e2b16)
- notice that the spinner appears and after a second it offers to download the file (since the embed failed)