### PR TITLE
Mitigate failed previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "test-chrome": "testcafe chrome ./tests/test.* --app \"node_modules/.bin/superstatic -p 5000 ./build -s\"",
     "test-firefox": "testcafe firefox ./tests/test.* --app \"node_modules/.bin/superstatic -p 5000 ./build -s\"",
     "test-safari": "testcafe safari ./tests/test.* --app \"node_modules/.bin/superstatic -p 5000 ./build -s\"",
-    "test": "testcafe chrome,firefox ./tests/test.* --app \"node_modules/.bin/superstatic -p 5000 ./build -s\""
+    "test": "testcafe chrome,firefox ./tests/test.* --app \"node_modules/.bin/superstatic -p 5000 ./build -s\"",
+    "test-headless": "testcafe chrome:headless,firefox:headless ./tests/test.* --app \"node_modules/.bin/superstatic -p 5000 ./build -s\""
   },
   "husky": {
     "hooks": {

--- a/src/App.js
+++ b/src/App.js
@@ -152,35 +152,17 @@ export default class App extends Component {
               </React.Fragment>
             )}
 
-            {this.props.manifest != null && (
-              <Router>
-                <CommonCartridge
-                  compact={this.props.compact}
-                  onHistoryChange={this.handleHistoryChange}
-                  manifest={this.props.manifest}
-                />
-              </Router>
-            )}
-
-            {this.props.cartridge != null && (
-              <Router>
-                <CommonCartridge
-                  cartridge={this.state.cartridge || this.state.file}
-                  compact={this.props.compact}
-                  onHistoryChange={this.handleHistoryChange}
-                />
-              </Router>
-            )}
-
-            {this.state.file != null && (
-              <Router>
-                <CommonCartridge
-                  compact={this.props.compact}
-                  file={this.state.file}
-                  onHistoryChange={this.handleHistoryChange}
-                />
-              </Router>
-            )}
+            <Router>
+              <CommonCartridge
+                manifest={this.props.manifest}
+                cartridge={this.state.cartridge || this.state.file}
+                file={this.state.file}
+                compact={this.props.compact}
+                onHistoryChange={this.handleHistoryChange}
+                onPreviewFailure={this.handlePreviewFailure}
+                previewType={this.state.previewType}
+              />
+            </Router>
           </View>
         )}
       </I18n>

--- a/tests/test.mitigate-preview-failure.js
+++ b/tests/test.mitigate-preview-failure.js
@@ -1,0 +1,55 @@
+import { Selector } from "testcafe";
+
+fixture`Mitigate Preview Failure`;
+
+const goodManifestUrlAndGoodImsccUrl = `http://localhost:5000/?manifest=${encodeURIComponent(
+  "/test-cartridges/course-1/imsmanifest.xml"
+)}&cartridge=${encodeURIComponent(
+  "http://s3.amazonaws.com/public-imscc/single-page.imscc"
+)}`;
+
+const badManifestUrlAndGoodImsccUrl = `http://localhost:5000/?manifest=${encodeURIComponent(
+  "/test-cartridges/course-1/imsmanifestDOESNOTEXIST.xml"
+)}&cartridge=${encodeURIComponent(
+  "http://s3.amazonaws.com/public-imscc/single-page.imscc"
+)}`;
+
+const badManifestUrlAndBadImsccUrl = `http://localhost:5000/?manifest=${encodeURIComponent(
+  "/test-cartridges/course-1/imsmanifestDOESNOTEXIST.xml"
+)}&cartridge=${encodeURIComponent(
+  "http://s3.amazonaws.com/public-imscc/single-pageDOESNOTEXIST.imscc"
+)}`;
+
+test("Manifest is preferred preview type", async t => {
+  await t.navigateTo(goodManifestUrlAndGoodImsccUrl);
+
+  await t
+    .expect(Selector("header").withText("COURSE-for-modules-testing").exists)
+    .ok()
+    .expect(Selector("a").withText("Assignments (2)").exists)
+    .ok()
+    .expect(Selector("a").withText("First Module Discussion 1").exists)
+    .ok()
+    .expect(Selector("header").withText("The Life of Paul").exists)
+    .notOk();
+});
+
+test("Bad manifest url falls back to previewing by imscc if present in url", async t => {
+  await t.navigateTo(badManifestUrlAndGoodImsccUrl);
+
+  await t
+    .expect(Selector("header").withText("The Life of Paul").exists)
+    .ok()
+    .expect(Selector("h1").withText("Our Purpose").exists)
+    .ok()
+    .expect(Selector("header").withText("COURSE-for-modules-testing").exists)
+    .notOk();
+});
+
+test("Bad manifest url & bad imscc url shows error page", async t => {
+  await t.navigateTo(badManifestUrlAndBadImsccUrl);
+
+  await t
+    .expect(Selector("span").withText("Failed to load resource").exists)
+    .ok();
+});


### PR DESCRIPTION
Note:
- A good local test url is: `http://localhost:3000/?manifest=/test-cartridges/course-1/imsmanifest.xml&cartridge=$SOME_GOOD_CARTRIDGE_URL_HERE.imscc#/`. (The manifest url and imscc url point to different cartridges so that you can see which one is being loaded. In production, they would both point to the same cartridge.)

Test Plan 1:
- Preview a cartridge by using a url that contains a good manifest url and a good imscc url.
- The cartridge preview works and uses the manifest url to load to page.
- NOTE: use a different cartridge for the manifest url and imscc url so you can see which one is being loaded.

Test Plan 2:
- Preview a cartridge by using a url that contains a bad manifest url and a good imscc url.
- The cartridge preview works and uses the imscc to load the page.

Test Plan 3:
- Preview a cartridge by using a url that contains a bad manifest url and a bad imscc url.
- The cartridge preview does not work and shows an error page saying the resource could not be loaded.

refs CM-697
fixes CM-738