### PR TITLE
Fix: nav buttons show up after using browser back/forward

### DIFF
--- a/src/AssessmentListItem.js
+++ b/src/AssessmentListItem.js
@@ -82,7 +82,7 @@ export default class AssessmentListItem extends Component {
                 as={RouterLink}
                 to={{
                   pathname,
-                  state: { from: this.props.from }
+                  search: this.props.search
                 }}
               >
                 {this.state.title}

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -65,7 +65,7 @@ export default class AssignmentListItem extends Component {
         title={this.state.title}
         points={this.state.points}
         workflowState={this.state.workflowState}
-        from={this.props.from}
+        search={this.props.search}
         resourceNotFound={this.state.resourceNotFound}
       />
     );

--- a/src/AssignmentListItemBody.js
+++ b/src/AssignmentListItemBody.js
@@ -21,7 +21,7 @@ export default class AssignmentListItemBody extends PureComponent {
               as={RouterLink}
               to={{
                 pathname,
-                state: { from: this.props.from }
+                search: this.props.search
               }}
             >
               {this.props.title}

--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -73,7 +73,7 @@ export default class AssociatedContentAssignmentListItem extends Component {
         description={this.state.workflowState}
         points={this.state.pointsPossible}
         workflowState={this.state.workflowState}
-        from={this.props.from}
+        search={this.props.search}
         resourceNotFound={this.state.resourceNotFound}
       />
     );

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -453,7 +453,8 @@ export default class CommonCartridge extends Component {
                           }}
                         >
                           <Trans>
-                            Discussions ({this.state.discussionResources.length})
+                            Discussions ({this.state.discussionResources.length}
+                            )
                           </Trans>
                         </NavLink>
                       )}
@@ -504,7 +505,7 @@ export default class CommonCartridge extends Component {
                       <Route
                         exact
                         path="/"
-                        render={({ match }) => (
+                        render={({ match, location }) => (
                           <React.Fragment>
                             {this.state.showcaseSingleResource !== null ? (
                               <React.Fragment>
@@ -525,6 +526,7 @@ export default class CommonCartridge extends Component {
                                   resourceIdsByHrefMap={
                                     this.state.resourceIdsByHrefMap
                                   }
+                                  location={location}
                                 />
                               </React.Fragment>
                             ) : this.state.showcaseResources.length === 1 ? (
@@ -546,6 +548,7 @@ export default class CommonCartridge extends Component {
                                   resourceIdsByHrefMap={
                                     this.state.resourceIdsByHrefMap
                                   }
+                                  location={location}
                                 />
                               </React.Fragment>
                             ) : (
@@ -559,6 +562,7 @@ export default class CommonCartridge extends Component {
                                   moduleItems={this.state.moduleItems}
                                   modules={this.state.modules}
                                   match={match}
+                                  location={location}
                                 />
                               </React.Fragment>
                             )}
@@ -599,7 +603,7 @@ export default class CommonCartridge extends Component {
                       <Route
                         exact
                         path="/modules/:module"
-                        render={({ match }) => (
+                        render={({ match, location }) => (
                           <React.Fragment>
                             <ModulesList
                               getTextByPath={this.getTextByPath}
@@ -609,6 +613,7 @@ export default class CommonCartridge extends Component {
                               moduleItems={this.state.moduleItems}
                               modules={this.state.modules}
                               match={match}
+                              location={location}
                             />
                           </React.Fragment>
                         )}

--- a/src/DiscussionListItem.js
+++ b/src/DiscussionListItem.js
@@ -77,7 +77,7 @@ export default class DiscussionListItem extends Component {
               as={RouterLink}
               to={{
                 pathname,
-                state: { from: this.props.from }
+                search: this.props.search
               }}
             >
               {this.state.title}

--- a/src/ExternalToolListItem.js
+++ b/src/ExternalToolListItem.js
@@ -20,7 +20,7 @@ export default class ExternalToolListItem extends Component {
               as={NavLink}
               to={{
                 pathname: `external/tool/${this.props.identifier}`,
-                state: { from: this.props.from }
+                search: this.props.search
               }}
             >
               <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -62,7 +62,7 @@ export default class FileListItem extends Component {
               as={RouterLink}
               to={{
                 pathname: `resources/${this.props.identifier}`,
-                state: { from: this.props.from }
+                search: this.props.search
               }}
             >
               {this.props.title || title}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -20,9 +20,13 @@ import { Trans } from "@lingui/macro";
 import { getAssignmentSettingsHref } from "./utils.js";
 import AssociatedContentAssignmentListItem from "./AssociatedContentAssignmentListItem";
 import ExternalToolListItem from "./ExternalToolListItem";
+const queryString = require("query-string");
 
 export default class ModulesList extends Component {
   render() {
+    const query = queryString.parse(this.props.location.search);
+    query.from = MODULE_LIST;
+    const search = queryString.stringify(query);
     const moduleComponents = this.props.modules.map(
       ({ title, ref, items, identifier }, index) => {
         const itemComponents = items.map((item, index) => {
@@ -53,7 +57,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }
@@ -68,7 +72,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }
@@ -87,7 +91,7 @@ export default class ModulesList extends Component {
                   item={item}
                   key={index}
                   src={this.props.src}
-                  from={MODULE_LIST}
+                  search={search}
                 />
               );
             }
@@ -103,7 +107,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }
@@ -118,7 +122,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }
@@ -133,7 +137,7 @@ export default class ModulesList extends Component {
                 metadata={item.metadata}
                 src={this.props.src}
                 title={item.title}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }
@@ -144,7 +148,7 @@ export default class ModulesList extends Component {
                 key={index}
                 identifier={item.identifierref}
                 item={item}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }
@@ -155,7 +159,7 @@ export default class ModulesList extends Component {
                 key={index}
                 item={item}
                 identifier={item.identifierref}
-                from={MODULE_LIST}
+                search={search}
               />
             );
           }

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -26,6 +26,7 @@ import { Trans } from "@lingui/macro";
 import EmbeddedPreview from "./EmbeddedPreview";
 import ResourceUnavailable from "./ResourceUnavailable";
 import PreviewUnavailable from "./PreviewUnavailable";
+const queryString = require("query-string");
 
 export default class Resource extends Component {
   constructor(props) {
@@ -98,7 +99,7 @@ export default class Resource extends Component {
           <Button
             to={{
               pathname: this.makeNavigationButtonHrefFromModule(previousItem),
-              state: this.props.location.state
+              search: this.props.location.search
             }}
             variant="ghost"
             as={RouterLink}
@@ -119,7 +120,7 @@ export default class Resource extends Component {
           <Button
             to={{
               pathname: this.makeNavigationButtonHrefFromModule(nextItem),
-              state: this.props.location.state
+              search: this.props.location.search
             }}
             variant="ghost"
             as={RouterLink}
@@ -304,10 +305,8 @@ export default class Resource extends Component {
     const currentIndex = moduleItems.findIndex(item => `${item.href}` === href);
     const previousItem = currentIndex > -1 && moduleItems[currentIndex - 1];
     const nextItem = currentIndex > -1 && moduleItems[currentIndex + 1];
-    const navigationButtonsEnabled =
-      this.props.location &&
-      this.props.location.state &&
-      this.props.location.state.from === MODULE_LIST;
+    const query = queryString.parse(this.props.location.search);
+    const navigationButtonsEnabled = query.from === MODULE_LIST;
     return (
       <React.Fragment>
         {navigationButtonsEnabled && (previousItem || nextItem) && (

--- a/src/WebLinkListItem.js
+++ b/src/WebLinkListItem.js
@@ -24,7 +24,7 @@ export default class WebLinkListItem extends Component {
                 as={NavLink}
                 to={{
                   pathname: `resources/${this.props.identifier}`,
-                  state: { from: this.props.from }
+                  search: this.props.search
                 }}
               >
                 <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>

--- a/src/WikiContentListItem.js
+++ b/src/WikiContentListItem.js
@@ -75,7 +75,7 @@ export default class WikiContentListItem extends Component {
               as={RouterLink}
               to={{
                 pathname,
-                state: { from: this.props.from }
+                search: this.props.search
               }}
             >
               {this.state.title || basename(this.props.href)}

--- a/tests/test.content-nav.js
+++ b/tests/test.content-nav.js
@@ -1,4 +1,7 @@
-import { Selector } from "testcafe";
+import { Selector, ClientFunction } from "testcafe";
+
+const browserBack = ClientFunction(() => window.history.back());
+const browserForward = ClientFunction(() => window.history.forward());
 
 fixture`Content Navigation links (Next & Previous)`;
 
@@ -228,6 +231,73 @@ test("Previous link on last page works", async t => {
       Selector("h1").withText("Assignment with Internal and External Links")
         .exists
     )
+    .ok();
+});
+
+test("Previous and Next buttons show up after using the 'back' browser button", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleQuiz1 = Selector("a").withText("First Module Quiz 1");
+  const firstModuleQuiz1Header = Selector("h1").withText("First Module Quiz 1");
+  const firstModuleWikiPage1Header = Selector("h1").withText(
+    "First Module Wiki Page 1"
+  );
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  await t
+    .click(firstModuleQuiz1)
+    .click(nextButton)
+    .expect(firstModuleWikiPage1Header.exists)
+    .ok();
+
+  await browserBack();
+
+  await t
+    .expect(firstModuleQuiz1Header.exists)
+    .ok()
+    .expect(nextButton.exists)
+    .ok()
+    .expect(previousButton.exists)
+    .ok();
+});
+
+test("Previous and Next buttons show up after using the 'forward' browser button", async t => {
+  const nextButton = Selector("span")
+    .withText("Next")
+    .parent("a");
+  const previousButton = Selector("span")
+    .withText("Previous")
+    .parent("a");
+  const firstModuleQuiz1 = Selector("a").withText("First Module Quiz 1");
+  const firstModuleQuiz1Header = Selector("h1").withText("First Module Quiz 1");
+  await t.navigateTo(
+    `http://localhost:5000/?manifest=${encodeURIComponent(
+      "/test-cartridges/course-1/imsmanifest.xml"
+    )}#/`
+  );
+
+  await t
+    .click(firstModuleQuiz1)
+    .expect(firstModuleQuiz1Header.exists)
+    .ok();
+
+  await browserBack();
+  await browserForward();
+
+  await t
+    .expect(firstModuleQuiz1Header.exists)
+    .ok()
+    .expect(nextButton.exists)
+    .ok()
+    .expect(previousButton.exists)
     .ok();
 });
 


### PR DESCRIPTION
This commit changes the way we are detecting whether the user came from the Module List (which determines whether we show the navigation buttons). 
Instead of using React Router state we are now using query params. 

Test Plan:
- Preview a cartridge
- Click on an item from the module list
- Press the browser back button
- You are back on the module list page
- Press the browser forward button
- You are back on the resource page
- The previous & next buttons are visible

Test Plan 2:
- Preview a cartridge
- Click on an item from the module list
- Click "Next" to navigate to the next page
- You are on a new resource page
- Press the browser back button
- You are back on the original resource page
- The previous & next buttons are visible

fixes CM-702