### PR TITLE
Improve the way module items are handled

### DIFF
--- a/src/AssessmentListItem.js
+++ b/src/AssessmentListItem.js
@@ -68,6 +68,8 @@ export default class AssessmentListItem extends Component {
 
     const pathname = this.state.resourceNotFound
       ? `resources/unavailable`
+      : this.props.isModuleItem
+      ? `module-items/${this.props.identifier}`
       : `resources/${this.props.identifier}`;
 
     return (
@@ -81,8 +83,7 @@ export default class AssessmentListItem extends Component {
               <Link
                 as={RouterLink}
                 to={{
-                  pathname,
-                  search: this.props.search
+                  pathname
                 }}
               >
                 {this.state.title}

--- a/src/AssignmentListItem.js
+++ b/src/AssignmentListItem.js
@@ -65,8 +65,8 @@ export default class AssignmentListItem extends Component {
         title={this.state.title}
         points={this.state.points}
         workflowState={this.state.workflowState}
-        search={this.props.search}
         resourceNotFound={this.state.resourceNotFound}
+        isModuleItem={this.props.isModuleItem}
       />
     );
   }

--- a/src/AssignmentListItemBody.js
+++ b/src/AssignmentListItemBody.js
@@ -9,6 +9,8 @@ export default class AssignmentListItemBody extends PureComponent {
   render() {
     const pathname = this.props.resourceNotFound
       ? `resources/unavailable`
+      : this.props.isModuleItem
+      ? `module-items/${this.props.identifier}`
       : `resources/${this.props.identifier}`;
     return (
       <li className="ExpandCollapseList-item">
@@ -20,8 +22,7 @@ export default class AssignmentListItemBody extends PureComponent {
             <Link
               as={RouterLink}
               to={{
-                pathname,
-                search: this.props.search
+                pathname
               }}
             >
               {this.props.title}

--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -73,8 +73,8 @@ export default class AssociatedContentAssignmentListItem extends Component {
         description={this.state.workflowState}
         points={this.state.pointsPossible}
         workflowState={this.state.workflowState}
-        search={this.props.search}
         resourceNotFound={this.state.resourceNotFound}
+        isModuleItem={this.props.isModuleItem}
       />
     );
   }

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -602,6 +602,36 @@ export default class CommonCartridge extends Component {
 
                       <Route
                         exact
+                        path="/module-items/:identifier"
+                        render={({ match, location }) => (
+                          <React.Fragment>
+                            <Resource
+                              basepath={this.state.basepath}
+                              externalViewers={this.state.externalViewers}
+                              externalViewer={this.state.externalViewers.get(
+                                match.params.identifier
+                              )}
+                              getBlobByPath={this.getBlobByPath}
+                              getTextByPath={this.getTextByPath}
+                              getUrlForPath={this.getUrlForPath}
+                              identifier={match.params.identifier}
+                              isCartridgeRemotelyExpanded={
+                                this.state.isCartridgeRemotelyExpanded
+                              }
+                              moduleItems={this.state.moduleItems}
+                              modules={this.state.modules}
+                              resourceIdsByHrefMap={
+                                this.state.resourceIdsByHrefMap
+                              }
+                              resourceMap={this.state.resourceMap}
+                              isModuleItem={true}
+                            />
+                          </React.Fragment>
+                        )}
+                      />
+
+                      <Route
+                        exact
                         path="/modules/:module"
                         render={({ match, location }) => (
                           <React.Fragment>
@@ -732,36 +762,6 @@ export default class CommonCartridge extends Component {
                         exact
                         path="/course/navigation"
                         render={({ match }) => <CourseNavigationUnavailable />}
-                      />
-
-                      <Route
-                        exact
-                        path="/external/tool/:identifier"
-                        render={({ match, location }) => (
-                          <React.Fragment>
-                            <Resource
-                              basepath={this.state.basepath}
-                              externalViewers={this.state.externalViewers}
-                              externalViewer={this.state.externalViewers.get(
-                                match.params.identifier
-                              )}
-                              getBlobByPath={this.getBlobByPath}
-                              getTextByPath={this.getTextByPath}
-                              getUrlForPath={this.getUrlForPath}
-                              identifier={match.params.identifier}
-                              isCartridgeRemotelyExpanded={
-                                this.state.isCartridgeRemotelyExpanded
-                              }
-                              moduleItems={this.state.moduleItems}
-                              modules={this.state.modules}
-                              resourceIdsByHrefMap={
-                                this.state.resourceIdsByHrefMap
-                              }
-                              resourceMap={this.state.resourceMap}
-                              location={location}
-                            />
-                          </React.Fragment>
-                        )}
                       />
                     </Switch>
 

--- a/src/DiscussionListItem.js
+++ b/src/DiscussionListItem.js
@@ -63,6 +63,8 @@ export default class DiscussionListItem extends Component {
 
     const pathname = this.state.resourceNotFound
       ? `resources/unavailable`
+      : this.props.isModuleItem
+      ? `module-items/${this.props.identifier}`
       : `resources/${this.props.identifier}`;
 
     return (
@@ -76,8 +78,7 @@ export default class DiscussionListItem extends Component {
             <Link
               as={RouterLink}
               to={{
-                pathname,
-                search: this.props.search
+                pathname
               }}
             >
               {this.state.title}

--- a/src/ExternalToolListItem.js
+++ b/src/ExternalToolListItem.js
@@ -19,8 +19,9 @@ export default class ExternalToolListItem extends Component {
             <Link
               as={NavLink}
               to={{
-                pathname: `external/tool/${this.props.identifier}`,
-                search: this.props.search
+                pathname: this.props.isModuleItem
+                  ? `module-items/${this.props.identifier}`
+                  : `resources/${this.props.identifier}`
               }}
             >
               <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>

--- a/src/FileListItem.js
+++ b/src/FileListItem.js
@@ -61,8 +61,9 @@ export default class FileListItem extends Component {
             <Link
               as={RouterLink}
               to={{
-                pathname: `resources/${this.props.identifier}`,
-                search: this.props.search
+                pathname: this.props.isModuleItem
+                  ? `module-items/${this.props.identifier}`
+                  : `resources/${this.props.identifier}`
               }}
             >
               {this.props.title || title}

--- a/src/ModulesList.js
+++ b/src/ModulesList.js
@@ -3,11 +3,7 @@ import IconExternalLink from "@instructure/ui-icons/lib/Line/IconExternalLink";
 import Heading from "@instructure/ui-elements/lib/components/Heading";
 import Link from "@instructure/ui-elements/lib/components/Link";
 
-import {
-  resourceTypes,
-  WIKI_CONTENT_HREF_PREFIX,
-  MODULE_LIST
-} from "./constants";
+import { resourceTypes, WIKI_CONTENT_HREF_PREFIX } from "./constants";
 import NavLink from "./NavLink";
 import AssignmentListItem from "./AssignmentListItem";
 import AssessmentListItem from "./AssessmentListItem";
@@ -20,13 +16,9 @@ import { Trans } from "@lingui/macro";
 import { getAssignmentSettingsHref } from "./utils.js";
 import AssociatedContentAssignmentListItem from "./AssociatedContentAssignmentListItem";
 import ExternalToolListItem from "./ExternalToolListItem";
-const queryString = require("query-string");
 
 export default class ModulesList extends Component {
   render() {
-    const query = queryString.parse(this.props.location.search);
-    query.from = MODULE_LIST;
-    const search = queryString.stringify(query);
     const moduleComponents = this.props.modules.map(
       ({ title, ref, items, identifier }, index) => {
         const itemComponents = items.map((item, index) => {
@@ -57,7 +49,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                search={search}
+                isModuleItem={true}
               />
             );
           }
@@ -72,7 +64,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                search={search}
+                isModuleItem={true}
               />
             );
           }
@@ -91,7 +83,7 @@ export default class ModulesList extends Component {
                   item={item}
                   key={index}
                   src={this.props.src}
-                  search={search}
+                  isModuleItem={true}
                 />
               );
             }
@@ -107,7 +99,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                search={search}
+                isModuleItem={true}
               />
             );
           }
@@ -122,7 +114,7 @@ export default class ModulesList extends Component {
                 item={item}
                 key={index}
                 src={this.props.src}
-                search={search}
+                isModuleItem={true}
               />
             );
           }
@@ -137,7 +129,7 @@ export default class ModulesList extends Component {
                 metadata={item.metadata}
                 src={this.props.src}
                 title={item.title}
-                search={search}
+                isModuleItem={true}
               />
             );
           }
@@ -148,7 +140,7 @@ export default class ModulesList extends Component {
                 key={index}
                 identifier={item.identifierref}
                 item={item}
-                search={search}
+                isModuleItem={true}
               />
             );
           }
@@ -159,7 +151,7 @@ export default class ModulesList extends Component {
                 key={index}
                 item={item}
                 identifier={item.identifierref}
-                search={search}
+                isModuleItem={true}
               />
             );
           }

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -3,8 +3,7 @@ import React, { Component } from "react";
 import {
   resourceTypes,
   DOCUMENT_PREVIEW_EXTENSIONS_SUPPORTED,
-  NOTORIOUS_EXTENSIONS_SUPPORTED,
-  MODULE_LIST
+  NOTORIOUS_EXTENSIONS_SUPPORTED
 } from "./constants";
 import { Link as RouterLink } from "react-router-dom";
 import { saveAs } from "file-saver";
@@ -26,7 +25,6 @@ import { Trans } from "@lingui/macro";
 import EmbeddedPreview from "./EmbeddedPreview";
 import ResourceUnavailable from "./ResourceUnavailable";
 import PreviewUnavailable from "./PreviewUnavailable";
-const queryString = require("query-string");
 
 export default class Resource extends Component {
   constructor(props) {
@@ -88,8 +86,8 @@ export default class Resource extends Component {
   };
 
   makeNavigationButtonHrefFromModule = module =>
-    module.type === resourceTypes.EXTERNAL_TOOL
-      ? `/external/tool/${module.identifierref || module.identifier}`
+    this.props.isModuleItem
+      ? `/module-items/${module.identifierref || module.identifier}`
       : `/resources/${module.identifierref || module.identifier}`;
 
   renderPreviousButton = previousItem => {
@@ -98,8 +96,7 @@ export default class Resource extends Component {
         <Tooltip variant="inverse" tip={previousItem.title} placement="end">
           <Button
             to={{
-              pathname: this.makeNavigationButtonHrefFromModule(previousItem),
-              search: this.props.location.search
+              pathname: this.makeNavigationButtonHrefFromModule(previousItem)
             }}
             variant="ghost"
             as={RouterLink}
@@ -119,8 +116,7 @@ export default class Resource extends Component {
         <Tooltip variant="inverse" tip={nextItem.title} placement="start">
           <Button
             to={{
-              pathname: this.makeNavigationButtonHrefFromModule(nextItem),
-              search: this.props.location.search
+              pathname: this.makeNavigationButtonHrefFromModule(nextItem)
             }}
             variant="ghost"
             as={RouterLink}
@@ -286,16 +282,13 @@ export default class Resource extends Component {
   render() {
     let resource = this.props.resourceMap.get(this.props.identifier);
     const { moduleItems } = this.props;
-    const isExternalToolPath =
-      this.props.location &&
-      this.props.location.pathname &&
-      this.props.location.pathname.startsWith("/external/tool");
     const moduleItem = this.props.moduleItems.find(
       moduleItem => moduleItem.identifierref === this.props.identifier
     );
 
     const isValidExternalToolResource =
-      isExternalToolPath && moduleItem !== undefined;
+      moduleItem !== undefined &&
+      moduleItem.type === resourceTypes.EXTERNAL_TOOL;
 
     if (resource == null && isValidExternalToolResource === false) {
       return <ResourceUnavailable />;
@@ -305,21 +298,19 @@ export default class Resource extends Component {
     const currentIndex = moduleItems.findIndex(item => `${item.href}` === href);
     const previousItem = currentIndex > -1 && moduleItems[currentIndex - 1];
     const nextItem = currentIndex > -1 && moduleItems[currentIndex + 1];
-    const query = queryString.parse(this.props.location.search);
-    const navigationButtonsEnabled = query.from === MODULE_LIST;
     return (
       <React.Fragment>
-        {navigationButtonsEnabled && (previousItem || nextItem) && (
+        {this.props.isModuleItem && (previousItem || nextItem) && (
           <Flex margin="0 0 medium">
             <FlexItem padding="small" width="14rem">
-              {navigationButtonsEnabled &&
+              {this.props.isModuleItem &&
                 previousItem &&
                 this.renderPreviousButton(previousItem)}
             </FlexItem>
             <FlexItem padding="small" width="14rem" grow={true}>
               <Flex justifyItems="end">
                 <FlexItem>
-                  {navigationButtonsEnabled &&
+                  {this.props.isModuleItem &&
                     nextItem &&
                     this.renderNextButton(nextItem)}
                 </FlexItem>

--- a/src/WebLinkListItem.js
+++ b/src/WebLinkListItem.js
@@ -23,8 +23,9 @@ export default class WebLinkListItem extends Component {
               <Link
                 as={NavLink}
                 to={{
-                  pathname: `resources/${this.props.identifier}`,
-                  search: this.props.search
+                  pathname: this.props.isModuleItem
+                    ? `module-items/${this.props.identifier}`
+                    : `resources/${this.props.identifier}`
                 }}
               >
                 <span>{this.props.item.title || <Trans>Untitled</Trans>}</span>

--- a/src/WikiContentListItem.js
+++ b/src/WikiContentListItem.js
@@ -62,6 +62,8 @@ export default class WikiContentListItem extends Component {
 
     const pathname = this.state.resourceNotFound
       ? `resources/unavailable`
+      : this.props.isModuleItem
+      ? `module-items/${this.props.identifier}`
       : `resources/${this.props.identifier}`;
 
     return (
@@ -74,8 +76,7 @@ export default class WikiContentListItem extends Component {
             <Link
               as={RouterLink}
               to={{
-                pathname,
-                search: this.props.search
+                pathname
               }}
             >
               {this.state.title || basename(this.props.href)}

--- a/src/utils.js
+++ b/src/utils.js
@@ -273,7 +273,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
               return {
                 title,
                 type: resourceTypes.EXTERNAL_TOOL,
-                href: `#/external/tool/${identifierref}`,
+                href: `#/resources/${identifierref}`,
                 identifierref
               };
             }


### PR DESCRIPTION
This PR is an improvement on #139 suggested by @aaronshaf 
It changes the way we keep track of whether the user clicked on an item from the Module List or another location (which decides whether we show the nav buttons).

The main change is that instead of attaching a `from` query param to the URL, there is a new route called `module-items` that indicates whether the user is looking at a resource in the context of a module, or as a single resource. The hope is that this will make the distinction between viewing an item as a module item or a single-resource item more clear for both users and future contributors.

The test plan is the same as in #139 