### PR TITLE
show unpublished files as unpublished

### DIFF
--- a/public/test-cartridges/course-1/imsmanifest.xml
+++ b/public/test-cartridges/course-1/imsmanifest.xml
@@ -141,5 +141,34 @@
     <resource type="webcontent" identifier="i1f4fc3f7049fa09157a195fc3538f184" href="web_resources/sample.mp3">
       <file href="web_resources/sample.mp3"/>
     </resource>
+    <resource type="webcontent" identifier="publisheddocument" href="web_resources/published-document.pdf">
+      <file href="web_resources/published-document.pdf"/>
+    </resource>
+    <resource type="webcontent" identifier="publisheddocument" href="web_resources/published-document-2.pdf">
+      <metadata>
+        <lom:lom>
+          <lom:educational>
+            <lom:intendedEndUserRole>
+              <lom:source>IMSGLC_CC_Rolesv1p1</lom:source>
+              <lom:value>Learner</lom:value>
+            </lom:intendedEndUserRole>
+          </lom:educational>
+        </lom:lom>
+      </metadata>
+      <file href="web_resources/published-document-2.pdf"/>
+    </resource>
+    <resource type="webcontent" identifier="unpublisheddocument2" href="web_resources/unpublished-document.pdf">
+      <metadata>
+        <lom:lom>
+          <lom:educational>
+            <lom:intendedEndUserRole>
+              <lom:source>IMSGLC_CC_Rolesv1p1</lom:source>
+              <lom:value>Instructor</lom:value>
+            </lom:intendedEndUserRole>
+          </lom:educational>
+        </lom:lom>
+      </metadata>
+      <file href="web_resources/unpublished-document.pdf"/>
+    </resource>
   </resources>
 </manifest>

--- a/src/FileList.js
+++ b/src/FileList.js
@@ -19,7 +19,7 @@ export default class FileList extends Component {
       });
 
     const listItems = fileResources.map(
-      ({ dependencyHrefs, href, identifier }, index) => {
+      ({ dependencyHrefs, href, identifier, metadata }, index) => {
         return (
           <FileListItem
             dependencyHrefs={dependencyHrefs}
@@ -27,6 +27,7 @@ export default class FileList extends Component {
             identifier={identifier}
             key={index}
             src={this.props.src}
+            metadata={metadata}
           />
         );
       }

--- a/tests/test.files.js
+++ b/tests/test.files.js
@@ -10,3 +10,33 @@ test("Assignment items don't show up as files", async t => {
   );
   await t.expect(assignmentFileItem.exists).notOk();
 });
+
+test("Published files show up as published (no metadata case)", async t => {
+  await t
+    .expect(
+      Selector(".ExpandCollapseList-item-workflow-state").withExactText(
+        "published-document.pdf is published"
+      ).exists
+    )
+    .ok();
+});
+
+test("Published files show up as published (intended user role includes Learner case)", async t => {
+  await t
+    .expect(
+      Selector(".ExpandCollapseList-item-workflow-state").withExactText(
+        "published-document-2.pdf is published"
+      ).exists
+    )
+    .ok();
+});
+
+test("Unpublished files show up as unpublished", async t => {
+  await t
+    .expect(
+      Selector(".ExpandCollapseList-item-workflow-state").withExactText(
+        "unpublished-document.pdf is unpublished"
+      ).exists
+    )
+    .ok();
+});


### PR DESCRIPTION
fixes cm-779

root casuse: required props not passed to component

test plan:
  create a course in canvas and add both published unpublished files to it
  publish to commons
  open the course preview in commons and go to the files tab
  verify that unbpublished files show up as unpublished, and published files as published