### PR TITLE
Fix padding on question list numbering

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -56,7 +56,7 @@ ul.ExpandCollapseList {
 }
 
 ol.assessment-questions {
-  padding: 0 1rem;
+  padding: 0 40px;
 }
 
 .unstyled-list li {
@@ -235,7 +235,7 @@ td {
   }
 }
 
-/* 
+/*
   CSS Grid styles for the cartridge view
   and hamburger menu for mobile
 */


### PR DESCRIPTION
When a Quiz had more than 9 questions the additional digits where clipped.
This commit fixes that by adding enough padding so that
numbers up to 3 digits have enough space