### PR TITLE
Parse assignment description as html

### DIFF
--- a/src/AssociatedContentAssignmentListItem.js
+++ b/src/AssociatedContentAssignmentListItem.js
@@ -28,7 +28,7 @@ export default class AssociatedContentAssignmentListItem extends Component {
       });
       return;
     }
-    const doc = parser.parseFromString(assignmentXml, "text/xml");
+    const doc = parser.parseFromString(assignmentXml, "text/html");
     const title =
       doc.querySelector("title") &&
       doc
@@ -38,7 +38,7 @@ export default class AssociatedContentAssignmentListItem extends Component {
           ""
         );
 
-    const settingsXml = this.props.getTextByPath(
+    const settingsXml = await this.props.getTextByPath(
       getAssignmentSettingsHref(this.props.identifier)
     );
     const settings = parser.parseFromString(settingsXml, "text/xml");

--- a/src/Resource.js
+++ b/src/Resource.js
@@ -196,7 +196,7 @@ export default class Resource extends Component {
             />
           )}
           src={this.props.src}
-          type="text/xml"
+          type="text/html"
         />
       ),
       [resourceTypes.DISCUSSION_TOPIC]: (


### PR DESCRIPTION
AssociatedContentAssignmentListItem was parsing the assignment
description as xml, not the html it is. If the description included
unclosed elements (e.g. <img>), the result would be an error.

This lead to canvas ticket LA-584, where direct-shared assignments
could not be previewed.