### PR TITLE
Fixed a bug when we fail the whole manifest load on a null file resource

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -204,7 +204,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
         .map(resource =>
           resource.querySelector('file[href*="non_cc_assessment"]')
         )
-        .filter(file => file.getAttribute("href").includes(identifier));
+        .filter(file => file && file.getAttribute("href").includes(identifier));
 
       canvasFile &&
         resource


### PR DESCRIPTION
We fail the whole preview on simple missing property.

See [example resource,](https://common-cartridge-viewer.netlify.app/?compact&manifest=https://cartridge-manager-iad-prod.inscloudgate.net/entries-jwt/eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE1OTg1NDQ2NjIsImNhcnRyaWRnZV9pZCI6IjExOWE0YjUxODgwNTRlZjRiMGVmMWVlZTA0ZjRiOWUyIn0.kMwqvHwWwH-wE-qRkPt2LHR7vNIWabLkmIsGMs6tkhvjlD5_g_PvrF3z6TxMD4ZZpc3O3MQenZo-cwwzpQDYuw/119a4b5188054ef4b0ef1eee04f4b9e2/imsmanifest.xml&cartridge=https://pensieve-prod-cartridgesbucket-kgv84efgn6zd.s3.amazonaws.com/119a4b5188054ef4b0ef1eee04f4b9e2.imscc?AWSAccessKeyId=ASIAZIHRSNQUJDZD3JOJ&Expires=1597407504&Signature=Jl4cFU%2F9LlBibKCWNyCHdaE%2FDog%3D&x-amz-security-token=FwoGZXIvYXdzEK7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDN5IqjPrs7XfmXbdfyLHAc%2FpcS64GcZPYaWa%2FUyowqEF2InDsRL7NURujcOOJFn8%2FOens9%2B%2FzIbc2XgX6l28ABF2MXAQMIXgaNP96uOrct96AjgvamHkTnRl9wP7QNkAWqjW72F6CeKNcLh1eF0QIcT7nQFAjT%2BHSX8YgH4nPrIMAdaNQ%2FdtksmGDHySXpvrWFAJEm0trPmeqNz6jaoi44PBzHoBZzFDfjCgtxI8PgGeGElTmn4Di1XAlCQz41knSmYTcfWbAIDfWrgzJKkJtuf%2Flv9MzwsokLzP%2BQUyLWr6Sq3TeeHADnArfUQk%2FUYXddYBR9BXXm8rxsKA63xejZ%2FXZhFf5yFBHKOSWw%3D%3D&locale=en#/) that should work.
