### PR TITLE
- Display error message if imsmanifest.xml can't be found

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -205,7 +205,7 @@ export default class CommonCartridge extends Component {
       entry => entry.filename === "imsmanifest.xml"
     );
 
-    if (manifestEntry != null) {
+    if (manifestEntry) {
       let xml;
       try {
         xml = await getTextFromEntry(manifestEntry);
@@ -215,6 +215,8 @@ export default class CommonCartridge extends Component {
       if (xml != null) {
         this.loadResources(xml);
       }
+    } else {
+      this.setState({ errorLoading: true });
     }
   }
 


### PR DESCRIPTION
**Context**
I was getting a blank white screen whenever I dropped my .imscc file onto the page.

After some debugging I realised that I was building my export file incorrectly; file paths were being prepended with a `/` (so `/imsmanifest.xml` instead of `imsmanifest.xml`)

This was clearly an error on my side, but I think the app should still display an error message to tell the user that their file is not a valid Common Cartridge.

**Changes**
Display <Unavailable> error message if the `imsmanifest.xml` file can't be extracted.

