### PR TITLE
Add missing file node for Page resources

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -125,6 +125,15 @@ function $text(document, selector) {
   return node && node.textContent;
 }
 
+const addMissingFileNode = (node, dupes) => {
+  const href = node.getAttribute("href");
+  if (!node.hasChildNodes() && !dupes.has(href)) {
+    const fileNode = document.createElement("file");
+    fileNode.setAttribute("href", href);
+    node.appendChild(fileNode);
+  }
+};
+
 export const getOptionalTextContent = (node, selector) => {
   const queriedNode = node.querySelector(selector);
   return queriedNode ? queriedNode.textContent : "";
@@ -136,6 +145,7 @@ export function parseXml(xml) {
 }
 
 export function parseManifestDocument(manifest, { moduleMeta }) {
+  const dupes = new Set();
   const title = $text(manifest, "metadata > lom > general > title > string");
   const schema = $text(manifest, "metadata > schema");
   const schemaVersion = $text(manifest, "metadata > schemaversion");
@@ -182,6 +192,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
           return false;
         }
       }
+      addMissingFileNode(node, dupes);
       return true;
     })
     .filter(node => node.querySelector("file"))

--- a/tests/test.multiple-pages.js
+++ b/tests/test.multiple-pages.js
@@ -8,10 +8,12 @@ fixture`Course with multiple pages but no modules`
 test("Both page titles are displayed", async t => {
   await t.expect(Selector("li").withText(`First Page`).exists).ok();
   await t.expect(Selector("li").withText(`Second Page`).exists).ok();
+  await t.expect(Selector("li").withText(`Third Page`).exists).ok();
 });
 
 test("Link between pages", async t => {
   await t
+    .click(Selector("a").withText("Pages (3)"))
     .expect(Selector("a").withText("Second Page").exists)
     .ok()
     .click(Selector("a").withText("Second Page"))


### PR DESCRIPTION
A manifest generated by the current `canvas_cc` gem creates pageResources without a file node. Importing into then exporting from Canvas will generate courses with a proper manifest with a "Pages" section populated with web content. We also choose to ignore duplicate resources which can happen with the `canvas_cc` gem but are cleaned up when importing into Canvas.