### PR TITLE
Add missing file node for QTI Resources

### DIFF
--- a/public/test-cartridges/course-with-associated-content-assignments/e15f4285902a0458884f573e128eded9i/assessment_meta.xml
+++ b/public/test-cartridges/course-with-associated-content-assignments/e15f4285902a0458884f573e128eded9i/assessment_meta.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<quiz identifier="e15f4285902a0458884f573e128eded9i" xmlns="http://canvas.instructure.com/xsd/cccv1p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://canvas.instructure.com/xsd/cccv1p0 https://canvas.instructure.com/xsd/cccv1p0.xsd">
+  <title>Other Quiz</title>
+  <description>&lt;p&gt;This is a new quiz&lt;/p&gt;</description>
+  <shuffle_answers>false</shuffle_answers>
+  <scoring_policy>keep_highest</scoring_policy>
+  <hide_results></hide_results>
+  <quiz_type>assignment</quiz_type>
+  <points_possible>1.0</points_possible>
+  <require_lockdown_browser>false</require_lockdown_browser>
+  <require_lockdown_browser_for_results>false</require_lockdown_browser_for_results>
+  <require_lockdown_browser_monitor>false</require_lockdown_browser_monitor>
+  <lockdown_browser_monitor_data/>
+  <show_correct_answers>true</show_correct_answers>
+  <anonymous_submissions>false</anonymous_submissions>
+  <could_be_locked>true</could_be_locked>
+  <allowed_attempts>1</allowed_attempts>
+  <one_question_at_a_time>false</one_question_at_a_time>
+  <cant_go_back>false</cant_go_back>
+  <available>true</available>
+  <one_time_results>false</one_time_results>
+  <show_correct_answers_last_attempt>false</show_correct_answers_last_attempt>
+  <only_visible_to_overrides>false</only_visible_to_overrides>
+  <module_locked>false</module_locked>
+  <assignment identifier="ie99080e14d7bfc05e359a17925670348">
+    <title>Other Quiz</title>
+    <due_at/>
+    <lock_at/>
+    <unlock_at/>
+    <module_locked>false</module_locked>
+    <assignment_group_identifierref>ida04278ab1da4df263bbe8c21aef5dee</assignment_group_identifierref>
+    <workflow_state>published</workflow_state>
+    <assignment_overrides>
+    </assignment_overrides>
+    <quiz_identifierref>e15f4285902a0458884f573e128eded9i</quiz_identifierref>
+    <has_group_category>false</has_group_category>
+    <points_possible>1.0</points_possible>
+    <grading_type>points</grading_type>
+    <all_day>false</all_day>
+    <submission_types>online_quiz</submission_types>
+    <position>4</position>
+    <turnitin_enabled>false</turnitin_enabled>
+    <vericite_enabled>false</vericite_enabled>
+    <peer_review_count>0</peer_review_count>
+    <peer_reviews>false</peer_reviews>
+    <automatic_peer_reviews>false</automatic_peer_reviews>
+    <anonymous_peer_reviews>false</anonymous_peer_reviews>
+    <grade_group_students_individually>false</grade_group_students_individually>
+    <freeze_on_copy>false</freeze_on_copy>
+    <omit_from_final_grade>false</omit_from_final_grade>
+    <intra_group_peer_reviews>false</intra_group_peer_reviews>
+    <only_visible_to_overrides>false</only_visible_to_overrides>
+    <post_to_sis>false</post_to_sis>
+    <moderated_grading>false</moderated_grading>
+    <grader_count>0</grader_count>
+    <grader_comments_visible_to_graders>true</grader_comments_visible_to_graders>
+    <anonymous_grading>false</anonymous_grading>
+    <graders_anonymous_to_graders>false</graders_anonymous_to_graders>
+    <grader_names_visible_to_final_grader>true</grader_names_visible_to_final_grader>
+    <anonymous_instructor_annotations>false</anonymous_instructor_annotations>
+  </assignment>
+  <assignment_group_identifierref>ida04278ab1da4df263bbe8c21aef5dee</assignment_group_identifierref>
+  <assignment_overrides>
+  </assignment_overrides>
+</quiz>

--- a/public/test-cartridges/course-with-associated-content-assignments/imsmanifest.xml
+++ b/public/test-cartridges/course-with-associated-content-assignments/imsmanifest.xml
@@ -40,6 +40,9 @@
           <item identifier="i159319c8513b2c0f2e29bde7d9b942eb" identifierref="i9dede821e375f4888540a2095824f51e">
             <title>New Quiz</title>
           </item>
+          <item identifier="be249b9d7edb92e2f0c2b3158c913951i" identifierref="e15f4285902a0458884f573e128eded9i">
+            <title>Other Quiz</title>
+          </item>
         </item>
       </item>
     </organization>
@@ -89,6 +92,13 @@
     <resource identifier="icc89681ea9ad845e69a533543c3b1034" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="i9dede821e375f4888540a2095824f51e/assessment_meta.xml">
       <file href="i9dede821e375f4888540a2095824f51e/assessment_meta.xml"/>
       <file href="non_cc_assessments/i9dede821e375f4888540a2095824f51e.xml.qti"/>
+    </resource>
+    <resource identifier="e15f4285902a0458884f573e128eded9i" type="imsqti_xmlv1p2/imscc_xmlv1p1/assessment">
+      <dependency identifierref="icc89681ea9ad845e69a533543c3b1034"/>
+    </resource>
+    <resource identifier="icc89681ea9ad845e69a533543c3b1034" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="e15f4285902a0458884f573e128eded9i/assessment_meta.xml">
+      <file href="e15f4285902a0458884f573e128eded9i/assessment_meta.xml"/>
+      <file href="non_cc_assessments/e15f4285902a0458884f573e128eded9i.xml.qti"/>
     </resource>
     <resource type="webcontent" identifier="i4fb8ac263620615ac7660c7d37f60946" href="web_resources/sample-document.pdf">
       <file href="web_resources/sample-document.pdf"/>

--- a/public/test-cartridges/course-with-associated-content-assignments/imsmanifest.xml
+++ b/public/test-cartridges/course-with-associated-content-assignments/imsmanifest.xml
@@ -94,9 +94,10 @@
       <file href="non_cc_assessments/i9dede821e375f4888540a2095824f51e.xml.qti"/>
     </resource>
     <resource identifier="e15f4285902a0458884f573e128eded9i" type="imsqti_xmlv1p2/imscc_xmlv1p1/assessment">
-      <dependency identifierref="icc89681ea9ad845e69a533543c3b1034"/>
+      <!-- missing assessment_qti.xml file node -->
+      <dependency identifierref="4301b3c345335a96e548da9ae18698cci"/>
     </resource>
-    <resource identifier="icc89681ea9ad845e69a533543c3b1034" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="e15f4285902a0458884f573e128eded9i/assessment_meta.xml">
+    <resource identifier="4301b3c345335a96e548da9ae18698cci" type="associatedcontent/imscc_xmlv1p1/learning-application-resource" href="e15f4285902a0458884f573e128eded9i/assessment_meta.xml">
       <file href="e15f4285902a0458884f573e128eded9i/assessment_meta.xml"/>
       <file href="non_cc_assessments/e15f4285902a0458884f573e128eded9i.xml.qti"/>
     </resource>

--- a/public/test-cartridges/course-with-associated-content-assignments/non_cc_assessments/e15f4285902a0458884f573e128eded9i.xml.qti
+++ b/public/test-cartridges/course-with-associated-content-assignments/non_cc_assessments/e15f4285902a0458884f573e128eded9i.xml.qti
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<questestinterop xmlns="http://www.imsglobal.org/xsd/ims_qtiasiv1p2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/ims_qtiasiv1p2 http://www.imsglobal.org/xsd/ims_qtiasiv1p2p1.xsd">
+  <assessment ident="e15f4285902a0458884f573e128eded9i" title="Other Quiz">
+    <qtimetadata>
+      <qtimetadatafield>
+        <fieldlabel>cc_maxattempts</fieldlabel>
+        <fieldentry>1</fieldentry>
+      </qtimetadatafield>
+    </qtimetadata>
+    <section ident="root_section">
+      <item ident="id3e0aa4dc3d6ae38e9a675a47bec0e26" title="Question">
+        <itemmetadata>
+          <qtimetadata>
+            <qtimetadatafield>
+              <fieldlabel>question_type</fieldlabel>
+              <fieldentry>multiple_choice_question</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>points_possible</fieldlabel>
+              <fieldentry>1.0</fieldentry>
+            </qtimetadatafield>
+            <qtimetadatafield>
+              <fieldlabel>assessment_question_identifierref</fieldlabel>
+              <fieldentry>i33dca6697aa4c5c61572285f1a8e0a01</fieldentry>
+            </qtimetadatafield>
+          </qtimetadata>
+        </itemmetadata>
+        <presentation>
+          <material>
+            <mattext texttype="text/html">&lt;div&gt;&lt;p&gt;What is up?&lt;/p&gt;&lt;/div&gt;</mattext>
+          </material>
+          <response_lid ident="response1" rcardinality="Single">
+            <render_choice>
+              <response_label ident="883">
+                <material>
+                  <mattext texttype="text/plain">Yep</mattext>
+                </material>
+              </response_label>
+              <response_label ident="7444">
+                <material>
+                  <mattext texttype="text/plain">Nope</mattext>
+                </material>
+              </response_label>
+            </render_choice>
+          </response_lid>
+        </presentation>
+        <resprocessing>
+          <outcomes>
+            <decvar maxvalue="100" minvalue="0" varname="SCORE" vartype="Decimal"/>
+          </outcomes>
+          <respcondition continue="No">
+            <conditionvar>
+              <varequal respident="response1">883</varequal>
+            </conditionvar>
+            <setvar action="Set" varname="SCORE">100</setvar>
+          </respcondition>
+        </resprocessing>
+      </item>
+    </section>
+  </assessment>
+</questestinterop>

--- a/src/utils.js
+++ b/src/utils.js
@@ -214,7 +214,16 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
 
   const assessmentResources = resources
     .filter(is(resourceTypes.ASSESSMENT_CONTENT))
-    .filter(node => node.querySelector("file"));
+    .map(node => {
+      if (!node.querySelector("file")) {
+        // add missing file node for canvas_cc generated resources
+        const fileNode = document.createElement("file");
+        const href = node.getAttribute("identifier") + "/assessment_qti.xml";
+        fileNode.setAttribute("href", href);
+        node.appendChild(fileNode);
+      }
+      return node;
+    });
 
   const canvasAssessmentResources = resources
     .filter(

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,7 +215,7 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
   const assessmentResources = resources
     .filter(is(resourceTypes.ASSESSMENT_CONTENT))
     .map(node => {
-      if (!node.querySelector("file")) {
+      if (!node.querySelector("file") && node.querySelector("dependency")) {
         // add missing file node for canvas_cc generated resources
         const fileNode = document.createElement("file");
         const href = node.getAttribute("identifier") + "/assessment_qti.xml";
@@ -223,7 +223,8 @@ export function parseManifestDocument(manifest, { moduleMeta }) {
         node.appendChild(fileNode);
       }
       return node;
-    });
+    })
+    .filter(node => node.querySelector("file"));
 
   const canvasAssessmentResources = resources
     .filter(

--- a/tests/test.associated-content-assignment.js
+++ b/tests/test.associated-content-assignment.js
@@ -97,6 +97,26 @@ fixture`Associated-content assignments (loaded w/ src)`
   "/test-cartridges/course-with-associated-content-assignments/imsmanifest.xml"
 )}#/`;
 
+test("Associated-content quiz with assessment_qti.xml display correctly", async t => {
+  await t
+    .click(Selector("a").withText("Quizzes"))
+    .expect(Selector("a").withText("New Quiz").exists)
+    .ok()
+    .click(Selector("a").withText("New Quiz"))
+    .expect(Selector("h3").withText("Questions").exists)
+    .ok();
+});
+
+test("Associated-content quiz missing assessment_qti.xml display correctly", async t => {
+  await t
+    .click(Selector("a").withText("Quizzes"))
+    .expect(Selector("a").withText("Other Quiz").exists)
+    .ok()
+    .click(Selector("a").withText("Other Quiz"))
+    .expect(Selector("h3").withText("Questions").exists)
+    .ok();
+});
+
 test("Associated-content assignment items display correctly", async t => {
   await t
     .expect(Selector("a").withText("Published Assignment").exists)


### PR DESCRIPTION
A manifest generated by the current `canvas_cc` gem creates QTI resources without a file node. These quizzes are imported properly into Canvas. Although `canvas_cc` defines [ASSESSMENT_CC_QTI](https://github.com/instructure/canvas_cc/blob/master/lib/canvas_cc/cc/cc_helper.rb#L53), it's not used in the specs or examples. Adding the missing node in the CC Viewer allows the quizzes be parsed and rendered as they would when exported from Canvas.

```xml
<resource type="imsqti_xmlv1p2/imscc_xmlv1p1/assessment" identifier="IDENTIFIER">
  <file href="IDENTIFIER/assessment_qti.xml"/> <!-- missing -->
  <dependency identifierref="IDENTIFIER_meta"/>
</resource>
```
<img width="930" alt="quiz" src="https://github.com/instructure/common-cartridge-viewer/assets/17495/6d2058cb-d6ad-40c7-b387-6e0ea751c5bd">
