### PR TITLE
Use slug for subpage links

### DIFF
--- a/public/test-cartridges/multiple-pages/imsmanifest.xml
+++ b/public/test-cartridges/multiple-pages/imsmanifest.xml
@@ -46,5 +46,6 @@
     <resource identifier="b21fcf1e322b1d8263285fb6012b2b46c" type="webcontent" href="wiki_content/second-page.html">
       <file href="wiki_content/second-page.html"/>
     </resource>
+    <resource identifier="c64b2b2106bf5823628d1b223e1fcf12i" type="webcontent" href="wiki_content/third-page.html"/>
   </resources>
 </manifest>

--- a/public/test-cartridges/multiple-pages/wiki_content/second-page.html
+++ b/public/test-cartridges/multiple-pages/wiki_content/second-page.html
@@ -5,6 +5,9 @@
     <meta name="identifier" content="b21fcf1e322b1d8263285fb6012b2b46c" />
     <meta name="editing_roles" content="teachers" />
     <meta name="workflow_state" content="active" />
+   <style>body {font-size: 18pt; font-family: sans-serif;}</style>
   </head>
-  <body></body>
+  <body>
+    <p>Link to <a href="%24WIKI_REFERENCE%24/pages/c64b2b2106bf5823628d1b223e1fcf12i">Third Page</a>.</p>
+  </body>
 </html>

--- a/public/test-cartridges/multiple-pages/wiki_content/third-page.html
+++ b/public/test-cartridges/multiple-pages/wiki_content/third-page.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Third Page</title>
+    <meta name="identifier" content="c64b2b2106bf5823628d1b223e1fcf12i" />
+    <meta name="editing_roles" content="teachers" />
+    <meta name="workflow_state" content="active" />
+    <style>body {font-size: 18pt; font-family: sans-serif;}</style>
+  </head>
+  <body></body>
+</html>

--- a/src/RichContent.js
+++ b/src/RichContent.js
@@ -54,6 +54,8 @@ export default class RichContent extends Component {
           ) {
             const resourceId = this.props.resourceIdsByHrefMap.get(href);
             link.setAttribute("href", `#/resources/${resourceId}`);
+          } else if (slug) {
+            link.setAttribute("href", `#/resources/${slug}`);
           } else {
             link.setAttribute("href", `#/resources/unavailable`);
           }

--- a/tests/test.multiple-pages.js
+++ b/tests/test.multiple-pages.js
@@ -9,3 +9,15 @@ test("Both page titles are displayed", async t => {
   await t.expect(Selector("li").withText(`First Page`).exists).ok();
   await t.expect(Selector("li").withText(`Second Page`).exists).ok();
 });
+
+test("Link between pages", async t => {
+  await t
+    .expect(Selector("a").withText("Second Page").exists)
+    .ok()
+    .click(Selector("a").withText("Second Page"))
+    .expect(Selector("h1").withText("Second Page").exists)
+    .ok()
+    .click(Selector("a").withText("Third Page"))
+    .expect(Selector("h1").withText("Third Page").exists)
+    .ok();
+});


### PR DESCRIPTION
Cartridges created with the current canvas_cc gem can have subpages that are unreachable in the CC Viewer but work properly when imported into Canvas. When we fall back to using the slug, these links are restored.

This change in this PR was extracted from [PR 204](https://github.com/instructure/common-cartridge-viewer/pull/204).