### PR TITLE
Support decoded wiki links from Canvas.

### DIFF
--- a/public/test-cartridges/multiple-pages/wiki_content/second-page.html
+++ b/public/test-cartridges/multiple-pages/wiki_content/second-page.html
@@ -8,6 +8,7 @@
    <style>body {font-size: 18pt; font-family: sans-serif;}</style>
   </head>
   <body>
+    <p>Link to <a href="$WIKI_REFERENCE$/pages/i21fcf1e322b1d8263285fb6012b2b46c">First Page</a>.</p>
     <p>Link to <a href="%24WIKI_REFERENCE%24/pages/c64b2b2106bf5823628d1b223e1fcf12i">Third Page</a>.</p>
   </body>
 </html>

--- a/src/RichContent.js
+++ b/src/RichContent.js
@@ -6,6 +6,7 @@ import {
   CC_FILE_OLDFIX_DECODED,
   CC_FILE_PREFIX_DECODED,
   WIKI_REFERENCE,
+  WIKI_REFERENCE_DECODED,
   CANVAS_COURSE_REFERENCE,
   CANVAS_OBJECT_REFERENCE,
   resourceTypeToHref
@@ -37,11 +38,22 @@ export default class RichContent extends Component {
     const pagesCourseNavigation = RegExp(`${WIKI_REFERENCE}/pages/$`);
     {
       const wikiExp = RegExp(`${WIKI_REFERENCE}/(pages)/(.*)`);
-      const links = Array.from(fragment.querySelectorAll("a[href]")).filter(
-        link =>
-          wikiExp.test(link.getAttribute("href")) &&
-          pagesCourseNavigation.test(link.getAttribute("href")) === false
-      );
+      const links = Array.from(fragment.querySelectorAll("a[href]"))
+        .map(link => {
+          const href = link.getAttribute("href");
+          if (href.includes(WIKI_REFERENCE_DECODED)) {
+            link.setAttribute(
+              "href",
+              href.replace(WIKI_REFERENCE_DECODED, WIKI_REFERENCE)
+            );
+          }
+          return link;
+        })
+        .filter(
+          link =>
+            wikiExp.test(link.getAttribute("href")) &&
+            pagesCourseNavigation.test(link.getAttribute("href")) === false
+        );
       await Promise.all(
         links.map(async link => {
           const slug = (link.getAttribute("href") || "")

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,6 +3,7 @@ export const CC_FILE_PREFIX_OLD = "%24IMS_CC_FILEBASE%24"; // mistaken, replaced
 export const CC_FILE_PREFIX_DECODED = decodeURIComponent(CC_FILE_PREFIX);
 export const CC_FILE_OLDFIX_DECODED = decodeURIComponent(CC_FILE_PREFIX_OLD);
 export const WIKI_REFERENCE = "%24WIKI_REFERENCE%24";
+export const WIKI_REFERENCE_DECODED = decodeURIComponent(WIKI_REFERENCE);
 export const CANVAS_OBJECT_REFERENCE = "%24CANVAS_OBJECT_REFERENCE%24";
 export const CANVAS_COURSE_REFERENCE = "%24CANVAS_COURSE_REFERENCE%24";
 export const WIKI_CONTENT_HREF_PREFIX = "wiki_content";

--- a/tests/test.multiple-pages.js
+++ b/tests/test.multiple-pages.js
@@ -11,7 +11,7 @@ test("Both page titles are displayed", async t => {
   await t.expect(Selector("li").withText(`Third Page`).exists).ok();
 });
 
-test("Link between pages", async t => {
+test("Link to page with standard wiki_reference", async t => {
   await t
     .click(Selector("a").withText("Pages (3)"))
     .expect(Selector("a").withText("Second Page").exists)
@@ -21,5 +21,18 @@ test("Link between pages", async t => {
     .ok()
     .click(Selector("a").withText("Third Page"))
     .expect(Selector("h1").withText("Third Page").exists)
+    .ok();
+});
+
+test("Link to page with decoded wiki_reference", async t => {
+  await t
+    .click(Selector("a").withText("Pages (3)"))
+    .expect(Selector("a").withText("Second Page").exists)
+    .ok()
+    .click(Selector("a").withText("Second Page"))
+    .expect(Selector("h1").withText("Second Page").exists)
+    .ok()
+    .click(Selector("a").withText("First Page"))
+    .expect(Selector("h1").withText("First Page").exists)
     .ok();
 });


### PR DESCRIPTION
The CCV currently supports wiki page links like this `"%24WIKI_REFERENCE%24/pages/IDENTIFIER`, but courses exported from Canvas have wiki page links like this `$WIKI_REFERENCE$/pages/IDENTIFIER`. The CCV can support both formats.

```html
<body>
  <p>Link to <a href="$WIKI_REFERENCE$/pages/i21fcf1e322b1d8263285fb6012b2b46c">First Page</a>.</p>
  <p>Link to <a href="%24WIKI_REFERENCE%24/pages/c64b2b2106bf5823628d1b223e1fcf12i">Third Page</a>.</p>
</body>
```