### PR TITLE
Fix single resource preview

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -446,9 +446,6 @@ export default class CommonCartridge extends Component {
     );
 
     const startIndexQuery = queryString.stringify({ startIndex: 0 });
-    const singleResourceView =
-      this.state.showcaseSingleResource ||
-      this.state.showcaseResources.length === 1;
 
     return (
       <I18n>
@@ -470,14 +467,7 @@ export default class CommonCartridge extends Component {
               </View>
             )}
 
-            <div
-              className={[
-                "CommonCartridge--view",
-                singleResourceView ? "single-resource" : null
-              ]
-                .join(" ")
-                .trim()}
-            >
+            <div className="CommonCartridge--view">
               {this.state.showcaseSingleResource === null && (
                 <nav>
                   <input type="checkbox" id="NavTrigger" name="NavTrigger" />

--- a/src/index.css
+++ b/src/index.css
@@ -246,10 +246,6 @@ td {
   grid-template-columns: 200px 1fr;
 }
 
-.CommonCartridge--view.single-resource {
-  grid-template-columns: 1fr;
-}
-
 .CommonCartridge--view nav {
   padding-top: 20px;
 }


### PR DESCRIPTION
CM-2002. SIngle resource preview should be next to the navbar, not under it.

Test plan: 
-Create a course that only has 1 previewable resource
-Share it to Commons
-Wait for the preview to process
-The previewable resource should be displayed next to the navbar