### PR TITLE
Fix single resource preview

### DIFF
--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -446,6 +446,9 @@ export default class CommonCartridge extends Component {
     );
 
     const startIndexQuery = queryString.stringify({ startIndex: 0 });
+    const singleResourceView =
+      this.state.showcaseSingleResource ||
+      this.state.showcaseResources.length === 1;
 
     return (
       <I18n>
@@ -467,7 +470,14 @@ export default class CommonCartridge extends Component {
               </View>
             )}
 
-            <div className="CommonCartridge--view">
+            <div
+              className={[
+                "CommonCartridge--view",
+                singleResourceView ? "single-resource" : null
+              ]
+                .join(" ")
+                .trim()}
+            >
               {this.state.showcaseSingleResource === null && (
                 <nav>
                   <input type="checkbox" id="NavTrigger" name="NavTrigger" />

--- a/src/CommonCartridge.js
+++ b/src/CommonCartridge.js
@@ -344,7 +344,7 @@ export default class CommonCartridge extends Component {
       result.modules.length === 0 &&
       result.showcaseResources.length === 1 &&
       result.fileResources.length === 0
-        ? this.state.showcaseResources[0]
+        ? result.showcaseResources[0]
         : null;
 
     this.setState({
@@ -446,9 +446,6 @@ export default class CommonCartridge extends Component {
     );
 
     const startIndexQuery = queryString.stringify({ startIndex: 0 });
-    const singleResourceView =
-      this.state.showcaseSingleResource ||
-      this.state.showcaseResources.length === 1;
 
     return (
       <I18n>
@@ -473,7 +470,7 @@ export default class CommonCartridge extends Component {
             <div
               className={[
                 "CommonCartridge--view",
-                singleResourceView ? "single-resource" : null
+                this.state.showcaseSingleResource ? "single-resource" : null
               ]
                 .join(" ")
                 .trim()}

--- a/src/index.css
+++ b/src/index.css
@@ -246,6 +246,10 @@ td {
   grid-template-columns: 200px 1fr;
 }
 
+.CommonCartridge--view.single-resource {
+  grid-template-columns: 1fr;
+}
+
 .CommonCartridge--view nav {
   padding-top: 20px;
 }


### PR DESCRIPTION
CM-2002 and CM-2006. 
-undo PR220
-Fix wrongly assumed single-resource. Due to a typo a course with a single previewable resource was assumed to be a single-resource preview, however it should not be displayed like that, because it has a navbar.

Test plan:
-Create a course that only has 1 previewable resource and share it to Commons
-The previewable resource should be displayed next to the navbar
-Create a course that has more than 1 previewable resource
-The previewable resources should be displayed next to the navbar
-Create a single resource (assignment, page etc) and share it to Commons
-The previewable resource should be displayed without a navbar

