### PR TITLE
Fix Canvas file launch without UUID

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,7 @@ export function getReaderFromXHR(url) {
   const promise = new Promise((resolve, reject) => {
     request.open("GET", url, true);
     request.responseType = "blob";
+    request.withCredentials = true;
     request.onload = function() {
       resolve(request.response);
     };


### PR DESCRIPTION
fixes GROW-91

Test plan
- Set up the viewer in Canvas
- Send an assignment (or other object) to someone in Canvas
- Enable the disable_adding_uuid_verifier_in_api feature flag in Canvas
- Open the shared content and ensure you can see the preview