### PR TITLE
Revert "Fix Canvas file launch without UUID"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -29,7 +29,6 @@ export function getReaderFromXHR(url) {
   const promise = new Promise((resolve, reject) => {
     request.open("GET", url, true);
     request.responseType = "blob";
-    request.withCredentials = true;
     request.onload = function() {
       resolve(request.response);
     };


### PR DESCRIPTION
Reverts instructure/common-cartridge-viewer#235

Seems to be breaking production because of the InstFS CDN.